### PR TITLE
Mac projects how configured to use ResXFileCodeGenerator on their

### DIFF
--- a/INTV.Core/INTV.Core.Mac.csproj
+++ b/INTV.Core/INTV.Core.Mac.csproj
@@ -58,7 +58,9 @@
     <Compile Include="ComponentModel\ModelBase.cs" />
     <Compile Include="ComponentModel\PropertyChangedNotifier.cs" />
     <Compile Include="ComponentModel\RelayCommandBase.cs" />
-    <Compile Include="Resources\Strings.Designer.cs" />
+    <Compile Include="Resources\Strings.Designer.cs">
+      <DependentUpon>Strings.resx</DependentUpon>
+    </Compile>
     <Compile Include="Model\Device\CartridgePort.cs" />
     <Compile Include="Model\Device\Connection.cs" />
     <Compile Include="Model\Device\ConnectionType.cs" />
@@ -183,7 +185,11 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Model\Resources\intvfunhouse_gameinfo.xml" />
-    <EmbeddedResource Include="Resources\Strings.resx" />
+    <EmbeddedResource Include="Resources\Strings.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Strings.Designer.cs</LastGenOutput>
+      <CustomToolNamespace>INTV.Core.Resources</CustomToolNamespace>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <None Include="license.txt" />

--- a/INTV.Intellicart/INTV.Intellicart.Mac.csproj
+++ b/INTV.Intellicart/INTV.Intellicart.Mac.csproj
@@ -105,7 +105,9 @@
     <Compile Include="Model\IntellicartModel.cs" />
     <Compile Include="Properties\Settings.Mac.cs" />
     <Compile Include="ViewModel\IntellicartViewModel.cs" />
-    <Compile Include="Resources\Strings.Designer.cs" />
+    <Compile Include="Resources\Strings.Designer.cs">
+      <DependentUpon>Strings.resx</DependentUpon>
+    </Compile>
     <Compile Include="ViewModel\SettingsPageViewModel.cs" />
     <Compile Include="View\IntellicartSettingsPage.Mac.cs" />
     <Compile Include="View\IntellicartSettingsPage.Mac.designer.cs">
@@ -122,7 +124,11 @@
     <None Include="README.txt" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Resources\Strings.resx" />
+    <EmbeddedResource Include="Resources\Strings.resx">
+      <CustomToolNamespace>INTV.Intellicart.Resources</CustomToolNamespace>
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Strings.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
     <EmbeddedResource Include="Resources\Images\intellicart_32xMD.png">
       <LogicalName>Resources/Images/intellicart_32xMD.png</LogicalName>
     </EmbeddedResource>

--- a/INTV.LtoFlash/INTV.LtoFlash.Mac.csproj
+++ b/INTV.LtoFlash/INTV.LtoFlash.Mac.csproj
@@ -83,7 +83,9 @@
     <Compile Include="Model\MenuLayout.cs" />
     <Compile Include="Model\PresentationOrder.cs" />
     <Compile Include="Model\Program.cs" />
-    <Compile Include="Resources\Strings.Designer.cs" />
+    <Compile Include="Resources\Strings.Designer.cs">
+      <DependentUpon>Strings.resx</DependentUpon>
+    </Compile>
     <Compile Include="ViewModel\AddRomsToMenuData.cs" />
     <Compile Include="ViewModel\FileNodeColorViewModel.cs" />
     <Compile Include="ViewModel\FileNodeViewModel.cs" />
@@ -760,7 +762,11 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Resources\Strings.resx" />
+    <EmbeddedResource Include="Resources\Strings.resx">
+      <CustomToolNamespace>INTV.LtoFlash.Resources</CustomToolNamespace>
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Strings.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="View\MenuLayoutView.xib" />

--- a/INTV.Shared/INTV.Shared.Mac.csproj
+++ b/INTV.Shared/INTV.Shared.Mac.csproj
@@ -83,7 +83,9 @@
     <Compile Include="Utility\SerialPortDetector.cs" />
     <Compile Include="Utility\SingleInstanceApplication.cs" />
     <Compile Include="Utility\VisualHelpers.cs" />
-    <Compile Include="Resources\Strings.Designer.cs" />
+    <Compile Include="Resources\Strings.Designer.cs">
+      <DependentUpon>Strings.resx</DependentUpon>
+    </Compile>
     <Compile Include="Utility\OSDispatcher.cs" />
     <Compile Include="Model\SearchDirectories.cs" />
     <Compile Include="Model\Device\ConnectionMonitor.cs" />
@@ -400,7 +402,11 @@
     <EmbeddedResource Include="ViewModel\Resources\Images\delete_folder.png">
       <LogicalName>ViewModel/Resources/Images/delete_folder.png</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="Resources\Strings.resx" />
+    <EmbeddedResource Include="Resources\Strings.resx">
+      <CustomToolNamespace>INTV.Shared.Resources</CustomToolNamespace>
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Strings.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
     <EmbeddedResource Include="ViewModel\Resources\Images\Information_16x16.png">
       <LogicalName>ViewModel/Resources/Images/Information_16x16.png</LogicalName>
     </EmbeddedResource>

--- a/INTV.jzIntv/INTV.jzIntv.Mac.csproj
+++ b/INTV.jzIntv/INTV.jzIntv.Mac.csproj
@@ -54,10 +54,16 @@
     <Compile Include="Model\DisplayResolution.cs" />
     <Compile Include="Model\ProgramFile.cs" />
     <Compile Include="Model\ProgramFileHelpers.cs" />
-    <Compile Include="Resources\Strings.Designer.cs" />
+    <Compile Include="Resources\Strings.Designer.cs">
+      <DependentUpon>Strings.resx</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Resources\Strings.resx" />
+    <EmbeddedResource Include="Resources\Strings.resx">
+      <CustomToolNamespace>INTV.jzIntv.Resources</CustomToolNamespace>
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Strings.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Locutus/LtoFlash/LtoFlash.Mac.csproj
+++ b/Locutus/LtoFlash/LtoFlash.Mac.csproj
@@ -96,6 +96,9 @@
     </Compile>
     <Compile Include="View\MainWindowController.Mac.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Resources\Strings.Designer.cs">
+      <DependentUpon>Strings.resx</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="View\MainMenu.xib" />
@@ -148,5 +151,12 @@
     <BundleResource Include="full_credits.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </BundleResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\Strings.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Strings.Designer.cs</LastGenOutput>
+      <CustomToolNamespace>Locutus.Resources</CustomToolNamespace>
+    </EmbeddedResource>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Strings.resx files. Hopefully, this will continue to work in Unified in
future (there are some grumblings about this online...)

Sadly, at least in Xamarin Studio 5.8.3, it's necessary to manually
configure the tool namespace to get things working correctly.

Also, it seems that the namespace for the resource strings in the jzIntv
component's Strings.Designer.cs class is wrong. Guess they're not being
used anywhere yet... Or they're obsolete.