### PR TITLE
Ribbon combo boxes in old Ribbon library have a bug that results in a…

### DIFF
--- a/INTV.Shared/Converter/EnumStringConverter.cs
+++ b/INTV.Shared/Converter/EnumStringConverter.cs
@@ -49,7 +49,7 @@ namespace INTV.Shared.Converter
             Type enumType = GetEnumTypeFromParameter(parameter);
             EnsureConverterData(enumType);
             string userFacingString = null;
-            if (!_converterData.TryGetValue(value as string, out userFacingString))
+            if (string.IsNullOrEmpty(value as string) || !_converterData.TryGetValue(value as string, out userFacingString))
             {
                 // assume that the first value in the enum is the 'default'
                 var values = Enum.GetValues(enumType);


### PR DESCRIPTION
… null value being sent when the combo is initially opened in a two-way binding, and the value in the combo box is the first item in the list of values (index 0). Check for that.

This is an xp-only bug (old version of Ribbon).