### PR TITLE
Intvsteve fix xp jz intv settings crash

### DIFF
--- a/INTV.jzIntvUI/Commands/JzIntvLauncherCommandGroup.Mac.cs
+++ b/INTV.jzIntvUI/Commands/JzIntvLauncherCommandGroup.Mac.cs
@@ -40,10 +40,11 @@ namespace INTV.JzIntvUI.Commands
         #region LaunchInJzIntvCommand
 
         private const int SDLNotLoadedError = 133;
+        private const int SDLNotLoadedError_Sierra = 134;
 
         static partial void OSErrorHandler(Emulator emulator, string message, int exitCode, Exception exception)
         {
-            if (exitCode == SDLNotLoadedError)
+            if ((exitCode == SDLNotLoadedError) || (exitCode == SDLNotLoadedError_Sierra))
             {
                 if (OSMessageBox.Show(Resources.Strings.SDLNotFound_ErrorMessage, Resources.Strings.SDLNotFound_ErrorTitle, OSMessageBoxButton.YesNo) == OSMessageBoxResult.Yes)
                 {

--- a/INTV.jzIntvUI/View/JzIntvSettingsPageController.Mac.cs
+++ b/INTV.jzIntvUI/View/JzIntvSettingsPageController.Mac.cs
@@ -323,7 +323,6 @@ namespace INTV.JzIntvUI.View
             }
         }
 
-
         private void HandleViewModelPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)


### PR DESCRIPTION
Fix up a Mac issue - not a crash - oops.
Windows xp had a crash in which attempting to access Intellivoice, ECS, or JLP settings (if at defaults) from Ribbon in Windows xp would crash.