### PR TITLE
Defer the first InvalidateRequerySuggested to give the Mono framework…

### DIFF
--- a/INTV.Shared/Utility/SingleInstanceApplication.Mac.cs
+++ b/INTV.Shared/Utility/SingleInstanceApplication.Mac.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SingleInstanceApplication.Mac.cs" company="INTV Funhouse">
+// <copyright file="SingleInstanceApplication.Mac.cs" company="INTV Funhouse">
 // Copyright (c) 2014-2016 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
@@ -303,7 +303,9 @@ namespace INTV.Shared.Utility
                             }
                             break;
                         case FirstResponderValueName:
-                            INTV.Shared.ComponentModel.CommandManager.InvalidateRequerySuggested();
+                            // When called early during startup, it's possible the MonoMac system hasn't fully initialized yet, which
+                            // can cause spurious "InvalidCast" errors.
+                            BeginInvokeOnMainThread(() => INTV.Shared.ComponentModel.CommandManager.InvalidateRequerySuggested());
                             break;
                     }
                 }


### PR DESCRIPTION
… a little more time to finish initialization. Spurious crash. Of course... who's to say that BeingInvokeOnMainThread is any safer to call? ::P