### PR TITLE
IOKit buff to work better with USB.

### DIFF
--- a/INTV.Shared/Interop/IOKit/IOKitHelpers.cs
+++ b/INTV.Shared/Interop/IOKit/IOKitHelpers.cs
@@ -34,6 +34,19 @@ namespace INTV.Shared.Interop.IOKit
     /// </summary>
     public static class IOKitHelpers
     {
+        #region USBSpec.h
+
+        /// <summary>The key used to get the USB Vendor Name property from an instance of IOKitRegistryEntry.</summary>
+        public static readonly string kUSBVendorString = "USB Vendor Name";
+
+        /// <summary>The key used to get the USB Product Name property from an instance of IOKitRegistryEntry.</summary>
+        public static readonly string kUSBProductString = "USB Product Name";
+
+        /// <summary>The key used to get the USB Serial Number property from an instance of IOKitRegistryEntry.</summary>
+        public static readonly string kUSBSerialNumberString = "USB Serial Number";
+
+        #endregion // USBSpec.h
+
         /// <summary>
         /// Enumerates the serial ports.
         /// </summary>

--- a/INTV.Shared/Interop/IOKit/IOService.cs
+++ b/INTV.Shared/Interop/IOKit/IOService.cs
@@ -20,7 +20,6 @@
 
 #define USE_IOKIT_NOTIFICATIONS
 ////#define ENABLE_DEBUG_OUTPUT
-////#define TEST_IOREG
 
 using System.Collections.Generic;
 using System.Linq;
@@ -333,19 +332,6 @@ namespace INTV.Shared.Interop.IOKit
                     PublishNotificationIterator.EnumerateSerialPorts(null);
                     TerminateNotificationIterator.EnumerateSerialPorts(null);
                 }
-
-                // UNDONE The following was the beginnings of an experiment to
-                // use the ioreg command line facility to extract USB / serial port
-                // information from the system, rather than writing (likely buggy)
-                // bindings to IOKit. Didn't get very far.
-#if TEST_IOREG
-                // var cc = IOMachPort.GetUSBMatchDictionary();
-                var ioreg = "ioreg";
-                var ioregResults = RunExternalProgram.CallAndReturnStdOut(ioreg, "-al -c IOSerialBSDClient", null);
-                var plist = new PList();
-                plist.Parse(ioregResults);
-                DebugOutput(ioregResults);
-#endif // TEST_IOREG
             }
 
             internal override void StopInThread()

--- a/INTV.Shared/Interop/IOKit/NativeMethods.cs
+++ b/INTV.Shared/Interop/IOKit/NativeMethods.cs
@@ -102,9 +102,6 @@ namespace INTV.Shared.Interop.IOKit
         public static readonly string kUSBInterfaceProtocol = "bInterfaceProtocol";
         public static readonly string kUSBInterfaceStringIndex = "iInterface";
         public static readonly string kUSBConfigurationValue = "bConfigurationValue";
-        public static readonly string kUSBProductString = "USB Product Name";
-        public static readonly string kUSBVendorString = "USB Vendor Name";
-        public static readonly string kUSBSerialNumberString = "USB Serial Number";
         public static readonly string kUSB1284DeviceID = "1284 Device ID";
 
         #endregion // USBSpec.h


### PR DESCRIPTION
IOKitHelpers.cs: Expose public strings for enumerating information for USB devices.
IOMachPort.cs: Clean up USB services iterator API to accept vendor and product ID values in order to better enumerate USB devices.
IOService.cs: Removed the TEST_IOREG code. ioreg is available on dev systems, but may not always be available on all systems.
NativeMethods.cs: Strings relocated to public IOKitHelpers class.