### PR TITLE
LUI crashes early on launch - apparently before unhandled exception h…

### DIFF
--- a/INTV.LtoFlash/Utility/FTDIUtilities.WPF.cs
+++ b/INTV.LtoFlash/Utility/FTDIUtilities.WPF.cs
@@ -112,15 +112,22 @@ namespace INTV.LtoFlash.Utility
         private static IEnumerable<System.Diagnostics.FileVersionInfo> GetDriverFileVersions()
         {
             var driverFileVersions = new List<System.Diagnostics.FileVersionInfo>();
-            var searcher = new ManagementObjectSearcher("SELECT * FROM Win32_SystemDriver WHERE Name LIKE 'FTDIBUS'");
-            foreach (var driver in searcher.Get().Cast<ManagementObject>())
+            try
             {
-                var driverPath = driver["PathName"] as string;
-                if (!string.IsNullOrEmpty(driverPath) && System.IO.File.Exists(driverPath))
+                var searcher = new ManagementObjectSearcher("SELECT * FROM Win32_SystemDriver WHERE Name LIKE 'FTDIBUS'");
+                foreach (var driver in searcher.Get().Cast<ManagementObject>())
                 {
-                    var driverFileVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(driverPath);
-                    driverFileVersions.Add(driverFileVersion);
+                    var driverPath = driver["PathName"] as string;
+                    if (!string.IsNullOrEmpty(driverPath) && System.IO.File.Exists(driverPath))
+                    {
+                        var driverFileVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(driverPath);
+                        driverFileVersions.Add(driverFileVersion);
+                    }
                 }
+            }
+            catch (System.UnauthorizedAccessException)
+            {
+                // The above fails on guest user accounts - at least as tried in Windows Vista and Windows 7.
             }
 
             if (!driverFileVersions.Any())


### PR DESCRIPTION
…andler even gets a chance to be hooked up - when run on Guest account in Windows. This is because the WMI query to get FTDI driver version encounters System.UnauthorizedAccessException. So much for WMI queries...

Fortunately, that can be easily handled, and the fallback mechanism of just looking directly at the file still works. So to fix: Catch the exception in the FTDI version-check and move on.