### PR TITLE
The SerialPortSelectorViewModel will now react to 'disable' requests.…

### DIFF
--- a/INTV.Shared/ViewModel/SerialPortSelectorViewModel.cs
+++ b/INTV.Shared/ViewModel/SerialPortSelectorViewModel.cs
@@ -291,12 +291,26 @@ namespace INTV.Shared.ViewModel
 
         private void DeviceRemoved(object sender, INTV.Shared.Interop.DeviceManagement.DeviceChangeEventArgs e)
         {
-            if ((e.Type == INTV.Core.Model.Device.ConnectionType.Serial) && DeviceChange.IsDeviceChangeFromSystem(e.State))
+            if (e.Type == INTV.Core.Model.Device.ConnectionType.Serial)
             {
                 var removedDevice = AvailableSerialPorts.FirstOrDefault(p => p.PortName == e.Name);
-                if ((removedDevice != null) && AvailableSerialPorts.Remove(removedDevice))
+                if (DeviceChange.IsDeviceChangeFromSystem(e.State))
                 {
-                    INTV.Shared.ComponentModel.CommandManager.InvalidateRequerySuggested();
+                    if ((removedDevice != null) && AvailableSerialPorts.Remove(removedDevice))
+                    {
+                        INTV.Shared.ComponentModel.CommandManager.InvalidateRequerySuggested();
+                    }
+                }
+                else
+                {
+                    // Removal may also indicate that the device is not valid for use by the party responsible for showing the dialog.
+                    // In such a case, disable the item.
+                    if ((removedDevice != null) && !DisabledSerialPorts.Contains(e.Name))
+                    {
+                        removedDevice.IsSelectable = false;
+                        DisabledSerialPorts.Add(e.Name);
+                        INTV.Shared.ComponentModel.CommandManager.InvalidateRequerySuggested();
+                    }
                 }
             }
         }


### PR DESCRIPTION
… The case in which this arises is:

Say the dialog is asking the user to choose a serial port for LTO Flash! ... and while the dialog is up, the background worker determines that the port is NOT a valid LTO Flash! device. In that situation, the dialog will now disable the item so it cannot be selected. If the race condition arises in which a port was already selected, but becomes "bad", the result is undetermined. I.e. it has not been tested.