### PR TITLE
More move to consistent of how to get read-only file stream Change us…

### DIFF
--- a/INTV.LtoFlash/Commands/FirmwareCommandGroup.cs
+++ b/INTV.LtoFlash/Commands/FirmwareCommandGroup.cs
@@ -373,7 +373,7 @@ namespace INTV.LtoFlash.Commands
             var updateVersion = FirmwareRevisions.UnavailableFirmwareVersion;
             try
             {
-                using (var fileStream = new System.IO.FileStream(filePath, System.IO.FileMode.Open, System.IO.FileAccess.Read))
+                using (var fileStream = FileUtilities.OpenFileStream(filePath))
                 {
                     fileStream.Seek(FirmwareUpdateVersionOffset, System.IO.SeekOrigin.Begin);
                     var versionBuffer = new byte[4];

--- a/INTV.LtoFlash/Model/Commands/DownloadAndLaunch.cs
+++ b/INTV.LtoFlash/Model/Commands/DownloadAndLaunch.cs
@@ -18,6 +18,8 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 // </copyright>
 
+using INTV.Shared.Utility;
+
 namespace INTV.LtoFlash.Model.Commands
 {
     /// <summary>
@@ -51,7 +53,7 @@ namespace INTV.LtoFlash.Model.Commands
         /// <inheritdoc />
         public override object Execute(INTV.Shared.Model.IStreamConnection target, ExecuteDeviceCommandAsyncTaskData taskData, out bool succeeded)
         {
-            using (var data = new System.IO.FileStream(File.FileInfo.FullName, System.IO.FileMode.Open))
+            using (var data = FileUtilities.OpenFileStream(File.FileInfo.FullName))
             {
                 succeeded = ExecuteCommandWithData(target, taskData, data, () => taskData.Device.ConnectionState = ConnectionState.WaitForBeacon);
             }

--- a/INTV.LtoFlash/Model/Commands/FileSystemFile.cs
+++ b/INTV.LtoFlash/Model/Commands/FileSystemFile.cs
@@ -18,6 +18,8 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 // </copyright>
 
+using INTV.Shared.Utility;
+
 namespace INTV.LtoFlash.Model.Commands
 {
     /// <summary>
@@ -119,7 +121,7 @@ namespace INTV.LtoFlash.Model.Commands
         /// <inheritdoc />
         public override int Serialize(Core.Utility.BinaryWriter writer)
         {
-            using (var file = new System.IO.FileStream(FileInfo.FullName, System.IO.FileMode.Open, System.IO.FileAccess.Read))
+            using (var file = FileUtilities.OpenFileStream(FileInfo.FullName))
             {
                 file.CopyTo(writer.BaseStream);
             }

--- a/INTV.Shared/Model/Program/ProgramCollection.cs
+++ b/INTV.Shared/Model/Program/ProgramCollection.cs
@@ -143,7 +143,7 @@ namespace INTV.Shared.Model.Program
                 ProgramCollection programs = null;
                 if (File.Exists(path))
                 {
-                    using (var fileStream = new FileStream(path, FileMode.Open))
+                    using (var fileStream = FileUtilities.OpenFileStream(path))
                     {
                         var serializer = new System.Xml.Serialization.XmlSerializer(typeof(Program.ProgramCollection));
                         programs = serializer.Deserialize(fileStream) as ProgramCollection;


### PR DESCRIPTION
…ages of FileStream to use FileUtilities - which is how StorageAccess API is implemented.