### PR TITLE
Add check for extended peripheral compatibility flags sub-version in …

### DIFF
--- a/INTV.Core/Model/Program/FeatureCompatibility.cs
+++ b/INTV.Core/Model/Program/FeatureCompatibility.cs
@@ -84,6 +84,15 @@ namespace INTV.Core.Model.Program
                         offset = LuigiFeatureFlagsHelpers.IntellivisionIIOffset;
                     }
                     break;
+                case FeatureCategory.KeyboardComponent:
+                    offset = LuigiFeatureFlagsHelpers.KeyboardComponentOffset;
+                    break;
+                case FeatureCategory.Tutorvision:
+                    // For TutorVision, we need to enable the 'feature compatibility sub-version' as well as the feature itself.
+                    // This could be any value from 1..3 (two bits). Just enable minimum necessary version.
+                    luigiFeatureFlags |= (LuigiFeatureFlags)(1ul << LuigiFeatureFlagsHelpers.ExtendedPeripheralCompatibiltyVersionOffset);
+                    offset = LuigiFeatureFlagsHelpers.TutorVisionOffset;
+                    break;
                 case FeatureCategory.Jlp:
                     offset = LuigiFeatureFlagsHelpers.JlpAccelerationOffset;
                     break;
@@ -95,7 +104,7 @@ namespace INTV.Core.Model.Program
             }
             if (offset >= 0)
             {
-                luigiFeatureFlags = (LuigiFeatureFlags)((ulong)compatibility << offset);
+                luigiFeatureFlags |= (LuigiFeatureFlags)((ulong)compatibility << offset);
             }
 
             return luigiFeatureFlags;

--- a/INTV.Core/Model/RomMetadataFeatures.cs
+++ b/INTV.Core/Model/RomMetadataFeatures.cs
@@ -89,7 +89,7 @@ namespace INTV.Core.Model
                 // The second byte contains more compatibility:
                 // .   7   6   5   4   3   2   1   0
                 // +---+---+---+---+---+---+---+---+
-                // | rsvd  | rsvd  | rsvd  | INTY2 |    byte 1
+                // | rsvd  | rsvd  | TUTOR | INTY2 |    byte 1
                 // +---+---+---+---+---+---+---+---+
                 var featureBits = reader.ReadByte();
                 --remainingPayload;
@@ -97,6 +97,10 @@ namespace INTV.Core.Model
                 // Bits 0,1 are Intellivision II compatibility.
                 var compatibility = RawFeatureToFeatureCompatibility(featureBits & FeatureMask);
                 Features.IntellivisionII = compatibility;
+
+                // Bits 2,3 are TutorVision compatibility.
+                compatibility = RawFeatureToFeatureCompatibility((featureBits >> 2) & FeatureMask);
+                Features.Tutorvision = compatibility;
             }
             if (remainingPayload > 0)
             {


### PR DESCRIPTION
…LUIGI header.

Add support for TutorVision feature flags in LUIGI and ROM files.
Add Keyboard Component peripheral flag conversion support. (Was it accidentally removed before?)