### PR TITLE
XamMac: Fix release builds.

### DIFF
--- a/Locutus/LtoFlash/LtoFlash.XamMac.csproj
+++ b/Locutus/LtoFlash/LtoFlash.XamMac.csproj
@@ -74,7 +74,7 @@
         </Command>
       </CustomCommands>
     </CustomCommands>
-    <MonoBundlingExtraArgs></MonoBundlingExtraArgs>
+    <MonoBundlingExtraArgs>--registrar=dynamic</MonoBundlingExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|x86' ">
     <DebugType>none</DebugType>
@@ -125,7 +125,7 @@
     <TlsProvider>Default</TlsProvider>
     <LinkMode>None</LinkMode>
     <XamMacArch></XamMacArch>
-    <MonoBundlingExtraArgs></MonoBundlingExtraArgs>
+    <MonoBundlingExtraArgs>--registrar=dynamic</MonoBundlingExtraArgs>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
A recent change to default behavior of release builds causes a native linker error in the static class
registration code for types that use IKImageBrowserDataSource and
related types. Soution is to use additional MMP command line argument:
--registrar=dynamic which restores previous behavior. The new behavior
is to generate static registration code, which can greatly speed up
launch time.

It is unclear just *why* this problem happens in the INTV.LtoFlash
assembly. It's not obvious if the "obsolete" QTKit is being used
somehow. The interfaces the native linker complains about are:
IKImageBrowserDataSource
IKImageBrowserItem
IKImageBrowserView

Those types all seem to be in the ImageKit within Quartz. Perhaps
there's some other kind of problem involved.