### PR TITLE
Mac event handlers cleanup

### DIFF
--- a/INTV.Shared/View/ProgressIndicatorController.Mac.cs
+++ b/INTV.Shared/View/ProgressIndicatorController.Mac.cs
@@ -151,7 +151,12 @@ namespace INTV.Shared.View
             ProgressBar.Indeterminate = progressViewModel.IsIndeterminate;
         }
 
-        private void HandlePropertyChanged (object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        private void HandlePropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            this.HandleEventOnMainThread(sender, e, HandlePropertyChangedCore);
+        }
+
+        private void HandlePropertyChangedCore(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             var viewModel = ((ProgressIndicatorViewModel)View.DataContext);
             switch (e.PropertyName)

--- a/INTV.Shared/View/ReportDialogController.Mac.cs
+++ b/INTV.Shared/View/ReportDialogController.Mac.cs
@@ -237,7 +237,12 @@ namespace INTV.Shared.View
             this.RaiseChangeValueForKey("EmailTextColor");
         }
 
-        private void HandlePropertyChanged (object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        private void HandlePropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            this.HandleEventOnMainThread(sender, e, HandlePropertyChangedCore);
+        }
+
+        private void HandlePropertyChangedCore(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {

--- a/INTV.Shared/View/RomFeaturesConfigurationController.Mac.cs
+++ b/INTV.Shared/View/RomFeaturesConfigurationController.Mac.cs
@@ -75,7 +75,7 @@ namespace INTV.Shared.View
         private void Initialize()
         {
             ViewModel = new RomFeaturesConfigurationViewModel();
-            ViewModel.PropertyChanged += ViewModelPropertyChanged;
+            ViewModel.PropertyChanged += HandleViewModelPropertyChanged;
             DataContext = ViewModel;
         }
 
@@ -214,21 +214,26 @@ namespace INTV.Shared.View
         public override void AwakeFromNib()
         {
             FeaturePagesArrayController.SynchronizeCollection(ViewModel.FeatureGroups);
-            ViewModelPropertyChanged(ViewModel, new System.ComponentModel.PropertyChangedEventArgs("CurrentSelection"));
-            ViewModelPropertyChanged(ViewModel, new System.ComponentModel.PropertyChangedEventArgs("CurrentSelectionVisual"));
+            HandleViewModelPropertyChanged(ViewModel, new System.ComponentModel.PropertyChangedEventArgs("CurrentSelection"));
+            HandleViewModelPropertyChanged(ViewModel, new System.ComponentModel.PropertyChangedEventArgs("CurrentSelectionVisual"));
         }
 
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {
-            ViewModel.PropertyChanged -= ViewModelPropertyChanged;
+            ViewModel.PropertyChanged -= HandleViewModelPropertyChanged;
             // MonoMac has some problems w/ lifetime. This was an attempt to prevent leaking dialogs.
             // However, there are cases that result in over-release that are not easily identified.
             // So, leak it is! :(
             // base.Dispose(disposing);
         }
 
-        private void ViewModelPropertyChanged (object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        private void HandleViewModelPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            this.HandleEventOnMainThread(sender, e, HandleViewModelPropertyChangedCore);
+        }
+
+        private void HandleViewModelPropertyChangedCore(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {

--- a/INTV.Shared/View/SerialPortSelectorController.Mac.cs
+++ b/INTV.Shared/View/SerialPortSelectorController.Mac.cs
@@ -236,11 +236,18 @@ namespace INTV.Shared.View
                     }
                 }
             }
-            DataContext.AvailableSerialPorts.CollectionChanged += AvalailablePortsChanged;
-            DataContext.DisabledSerialPorts.CollectionChanged += DisabledPortsChanged;
+            DataContext.AvailableSerialPorts.CollectionChanged += HandleAvailablePortsChanged;
+            DataContext.DisabledSerialPorts.CollectionChanged += HandleDisabledPortsChanged;
         }
 
-        private void HandleWillDisplayCell (object sender, NSTableViewCellEventArgs e)
+        protected override void Dispose(bool disposing)
+        {
+            DataContext.AvailableSerialPorts.CollectionChanged -= HandleAvailablePortsChanged;
+            DataContext.DisabledSerialPorts.CollectionChanged -= HandleDisabledPortsChanged;
+            base.Dispose(disposing);
+        }
+
+        private void HandleWillDisplayCell(object sender, NSTableViewCellEventArgs e)
         {
             var cell = e.Cell as NSTextFieldCell;
             if (cell != null)
@@ -316,13 +323,24 @@ namespace INTV.Shared.View
             return true;
         }
 
-        private void AvalailablePortsChanged (object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        private void HandleAvailablePortsChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            this.HandleEventOnMainThread(sender, e, HandleAvailablePortsChangedCore);
+        }
+
+        private void HandleAvailablePortsChangedCore(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
         {
             SerialPortsListArrayController.SynchronizeCollection<SerialPortViewModel>(e);
         }
 
-        private void DisabledPortsChanged (object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        private void HandleDisabledPortsChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
         {
+            this.HandleEventOnMainThread(sender, e, HandleDisabledPortsChangedCore);
+        }
+
+        private void HandleDisabledPortsChangedCore(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            // TODO: Is there something we should implement here?
         }
 
         ///<summary>

--- a/INTV.Shared/View/SerialPortSelectorDialogController.Mac.cs
+++ b/INTV.Shared/View/SerialPortSelectorDialogController.Mac.cs
@@ -138,6 +138,11 @@ namespace INTV.Shared.View
 
         private void HandlePortSelectorPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
+            this.HandleEventOnMainThread(sender, e, HandlePortSelectorPropertyChangedCore);
+        }
+
+        private void HandlePortSelectorPropertyChangedCore(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
             switch (e.PropertyName)
             {
                 case SerialPortSelectorViewModel.SelectedSerialPortPropertyName:

--- a/INTV.Shared/View/VisualHelpers.Mac.cs
+++ b/INTV.Shared/View/VisualHelpers.Mac.cs
@@ -72,6 +72,24 @@ namespace INTV.Shared.View
         }
 
         /// <summary>
+        /// Ensures that an event handler is invoked on main the thread.
+        /// </summary>
+        /// <param name="instance">Typically a NSController or NSView that must handle an event from a ViewModel.</param>
+        /// <param name="sender">Sender of the orginal event.</param>
+        /// <param name="args">Event data.</param>
+        /// <param name="handler">The event handler to ensure is executed on the main thread.</param>
+        /// <typeparam name="TEventArgs">The data type of the event handler's data.</typeparam>
+        public static void HandleEventOnMainThread<TEventArgs>(this NSResponder instance, object sender, TEventArgs args, System.Action<object, TEventArgs> handler) where TEventArgs : System.EventArgs
+        {
+            if (!OSDispatcher.IsMainThread)
+            {
+                instance.InvokeOnMainThread(() => handler(sender, args));
+                return;
+            }
+            handler(sender, args);
+        }
+
+        /// <summary>
         /// Shows a modal dialog.
         /// </summary>
         /// <param name="window">The dialog to show.</param>


### PR DESCRIPTION
Reign in a few often-missed cross-thread problems. When long-running tasks are executed on a worker thread, if they cause changes in the model that the UI is watching for (typically via ViewModel), and attempt to update a UI visual, trouble can arise. Ensure these event handlers run in the UI thread.