### PR TITLE
Update ROM metadata parsing to spec.

### DIFF
--- a/INTV.Core/Model/Program/ProgramFeatures.cs
+++ b/INTV.Core/Model/Program/ProgramFeatures.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="ProgramFeatures.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2015 All Rights Reserved
+// Copyright (c) 2014-2017 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it

--- a/INTV.Core/Model/Program/RomFileMetadataProgramInformation.cs
+++ b/INTV.Core/Model/Program/RomFileMetadataProgramInformation.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="RomFileMetadataProgramInformation.cs" company="INTV Funhouse">
-// Copyright (c) 2016 All Rights Reserved
+// Copyright (c) 2016-2017 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ namespace INTV.Core.Model.Program
         /// <param name="rom">The ROM from which program information is collected.</param>
         public RomFileMetadataProgramInformation(IRom rom)
         {
-            _features = ProgramFeatures.EmptyFeatures.Clone();
+            _features = ProgramFeatures.DefaultFeatures.Clone();
             Metadata = Enumerable.Empty<RomMetadataBlock>();
             var romFormatRom = Rom.AsSpecificRomType<RomFormatRom>(rom);
             if (romFormatRom != null)

--- a/INTV.Core/Model/RomMetadataFeatures.cs
+++ b/INTV.Core/Model/RomMetadataFeatures.cs
@@ -63,9 +63,9 @@ namespace INTV.Core.Model
                 // The first byte contains compatibility:
                 // .   7   6   5   4   3   2   1   0
                 // +---+---+---+---+---+---+---+---+
-                // |  ECS  | 4CTRL | VOICE | KEYBD |    byte 0
+                // |  ECS  | rsvd | VOICE | KEYBD |    byte 0
                 // +---+---+---+---+---+---+---+---+
-                Features = new ProgramFeatures();
+                Features = ProgramFeatures.DefaultFeatures.Clone();
                 var featureBits = reader.ReadByte();
                 --remainingPayload;
 
@@ -77,8 +77,8 @@ namespace INTV.Core.Model
                 compatibility = RawFeatureToFeatureCompatibility((featureBits >> 2) & FeatureMask);
                 Features.Intellivoice = compatibility;
 
-                // Bits 4,5 are 4-controller capability (ignored)
-                compatibility = RawFeatureToFeatureCompatibility((featureBits >> 4) & FeatureMask);
+                // Bits 4,5 are reserved (used to be 4-controller capability) (ignored)
+                ////compatibility = RawFeatureToFeatureCompatibility((featureBits >> 4) & FeatureMask);
 
                 // Bits 6,7 are ECS compatibility.
                 compatibility = RawFeatureToFeatureCompatibility((featureBits >> 6) & FeatureMask);

--- a/INTV.Core/Model/RomMetadataIdTag.cs
+++ b/INTV.Core/Model/RomMetadataIdTag.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="RomMetadataIdTag.cs" company="INTV Funhouse">
-// Copyright (c) 2016 All Rights Reserved
+// Copyright (c) 2016-2017 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -64,6 +64,9 @@ namespace INTV.Core.Model
 
         /// <summary>The release license for the ROM.</summary>
         License = 0x09,
+
+        /// <summary>/// A description of the game./// </summary>
+        Description = 0x0A,
 
         //// IDs 0x10 - 0x1F are reserved for future use.
 


### PR DESCRIPTION
FIXED BUG: Was not reading CRC16 out of the metadata block properly, so only part of the metadata was going to be retrieved correctly.