### PR TITLE
In a specific corner case, if an error due to a missing file occurred…

### DIFF
--- a/INTV.LtoFlash/Model/Program.cs
+++ b/INTV.LtoFlash/Model/Program.cs
@@ -343,7 +343,7 @@ namespace INTV.LtoFlash.Model
                         fork = FileSystem.Forks.AddFork(Description.GetRom());
                         if (!System.IO.File.Exists(fork.FilePath))
                         {
-                            var message = string.Format(System.Globalization.CultureInfo.CurrentCulture, Resources.Strings.RomToLuigiFailed_OutputFileNotFound_Error_Format, Description.Rom.RomPath, System.IO.Path.GetFileNameWithoutExtension(filePath));
+                            var message = string.Format(System.Globalization.CultureInfo.CurrentCulture, Resources.Strings.RomToLuigiFailed_OutputFileNotFound_Error_Format, Description.Rom.RomPath, fork.FilePath);
                             throw new LuigiFileGenerationException(message, Resources.Strings.RomToLuigiFailed_OutputFileNotFound_Error_Description_Format);
                         }
                     }


### PR DESCRIPTION
… during certain sync operations, only a bare file name was reported - and not necessarily the correct one! Now, report the full path of the missing file in the error message.