### PR TITLE
FileSystemStatistics objects were comparing as not equal because they…

### DIFF
--- a/INTV.LtoFlash/Model/FileSystemStatistics.cs
+++ b/INTV.LtoFlash/Model/FileSystemStatistics.cs
@@ -193,6 +193,34 @@ namespace INTV.LtoFlash.Model
         }
 
         /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            var areEqual = base.Equals(obj);
+            var other = obj as FileSystemStatistics;
+            if (other != null)
+            {
+                areEqual = (VirtualBlocksAvailable == other.VirtualBlocksAvailable) &&
+                           (VirtualBlocksTotal == other.VirtualBlocksTotal) &&
+                           (PhysicalSectorsClean == other.PhysicalSectorsClean) && 
+                           (PhysicalBlocksTotal == other.PhysicalBlocksTotal) &&
+                           (PhysicalSectorErasures == other.PhysicalSectorErasures) &&
+                           (MetadataSectorErasures == other.MetadataSectorErasures) &&
+                           (VirtualToPhysicalMapVersion == other.VirtualToPhysicalMapVersion);
+                           // ignoring ReservedData
+            }
+            return areEqual;
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            int hashCode = (VirtualBlocksAvailable << 16) | VirtualBlocksTotal;
+            hashCode ^= (PhysicalSectorsClean << 16) | PhysicalBlocksTotal;
+            hashCode ^= (int)(PhysicalSectorErasures ^ MetadataSectorErasures ^ VirtualToPhysicalMapVersion);
+            return hashCode;
+        }
+
+        /// <inheritdoc />
         protected override int Deserialize(INTV.Core.Utility.BinaryReader reader)
         {
             VirtualBlocksAvailable = reader.ReadUInt16();


### PR DESCRIPTION
… were using simple reference-based compare. This was causing frequent 'value change' event firings that churned the UI when device is attached to the computer while the UI is running. Implement overloads of Equals and GetHashCode. Hopefully GetHashCode is reasonably implemented.