### PR TITLE
Fix issue #20 - https://github.com/intvsteve/VINTage/issues/20

### DIFF
--- a/INTV.Core/Model/Program/FeatureCompatibility.cs
+++ b/INTV.Core/Model/Program/FeatureCompatibility.cs
@@ -60,6 +60,24 @@ namespace INTV.Core.Model.Program
         public const FeatureCompatibility ValidFeaturesMask = (FeatureCompatibility)CompatibilityMask;
 
         /// <summary>
+        /// Coerces the given video standard compatibility to a supported value.
+        /// </summary>
+        /// <param name="videoStandardCompatiblity">The video standard compatibility to coerce.</param>
+        /// <returns>The coerced value.</returns>
+        /// <remarks>The ProgramFeatures.Combine() method had a bug that would result in combining the 'Tolerates' and 'Enhances' modes,
+        /// which resulted in a value of <see cref="FeatureCompatibility.Required"/>. This method is used internally to correct for the problem.
+        /// To do so, it will strip the FeatureCompatibility.Tolerates bit. Recall that for video standards, FeatureCompatibility.Enhanced
+        /// indicates that video standard compatibility is unknown.</remarks>
+        public static FeatureCompatibility CoerceVideoStandardCompatibility(this FeatureCompatibility videoStandardCompatiblity)
+        {
+            if (videoStandardCompatiblity == FeatureCompatibility.Requires)
+            {
+                videoStandardCompatiblity = FeatureCompatibility.Enhances; // Indicates compatibility is unknown.
+            }
+            return videoStandardCompatiblity;
+        }
+
+        /// <summary>
         /// Converts standard FeatureCompatibility to LuigiFeatureFlags.
         /// </summary>
         /// <param name="compatibility">The compatibility to convert.</param>

--- a/INTV.Core/Model/Program/IntvFunhouseXmlProgramInformation.cs
+++ b/INTV.Core/Model/Program/IntvFunhouseXmlProgramInformation.cs
@@ -83,7 +83,7 @@ namespace INTV.Core.Restricted.Model.Program
         public int NtscCompatibility
         {
             get { return _ntsc; }
-            set { _ntsc = value; }
+            set { _ntsc = (int)((FeatureCompatibility)value).CoerceVideoStandardCompatibility(); }
         }
 
         /// <summary>
@@ -93,7 +93,7 @@ namespace INTV.Core.Restricted.Model.Program
         public int PalCompatibility
         {
             get { return _pal; }
-            set { _pal = value; }
+            set { _pal = (int)((FeatureCompatibility)value).CoerceVideoStandardCompatibility(); }
         }
 
         /// <summary>


### PR DESCRIPTION
When adding a new ROM, we will combine features. If the new ROM is unknown, it would "combine" the 'Tolerates' setting (default for most) with 'Enhances' for video standard support - which means 'Unknown'. However, the result is that the ORing of those together produces a 'required' value for the video standard, which does not make sense.

To address existing behavior of saved ROM lists, coerce the read and and write operations on the Ntsc and Pal properties.

Also, fix how flags are combined to prevent this escalation from happening with other features. Unfortunately, if there are bugged ROM files out there for things like JLP and other features, they will remain bugged until the user manually fixes them, or deletes / re-adds the ROM after getting this fix.