### PR TITLE
To fix these, remove what is in retrospect an unwise part of the UI t…

### DIFF
--- a/Locutus/LtoFlash/View/MainWindow.xaml
+++ b/Locutus/LtoFlash/View/MainWindow.xaml
@@ -587,9 +587,7 @@
                                         <RotateTransform Angle="90"/>
                                     </Separator.LayoutTransform>
                                 </Separator>
-                                <TextBlock Text="{Binding MenuLayout.LongName}"/>
-                                <TextBlock Text=" :"/>
-                                <TextBlock Margin="4,0,0,0" Text="{Binding MenuLayout.Status}"/>
+                                <TextBlock Margin="0" Text="{Binding MenuLayout.Status}"/>
                             </StackPanel>
                         </Border>
                         <Border Grid.Column="1" BorderThickness="0,1,0,1" BorderBrush="LightGray" Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}">


### PR DESCRIPTION
…o add in the first place.

In Windows:
* **Issue 114:** Switching does not update menu information: This should not be udpated. The menu layout part of the window shows the on-disk menu, not the device's menu. The device menu information is not displayed in the UI at this time.
* **Issue 115:** Menu layout shows device owner, not name: The problem here is that this will be empty unless a menu was created by fetching it from a cart. This simply does not belong in the UI here.

This will need to be fixed on Mac and GTK as well.