### PR TITLE
Fix device history

### DIFF
--- a/INTV.Intellicart/Model/IntellicartModel.cs
+++ b/INTV.Intellicart/Model/IntellicartModel.cs
@@ -178,6 +178,12 @@ namespace INTV.Intellicart.Model
             get { return Id; }
         }
 
+        /// <inheritdoc/>
+        public IEnumerable<IPeripheral> AttachedPeripherals
+        {
+            get { yield break; }
+        }
+
         #endregion // IPrimaryComponent Properties
 
         #endregion // Properties

--- a/INTV.LtoFlash/Model/Device.cs
+++ b/INTV.LtoFlash/Model/Device.cs
@@ -1253,10 +1253,7 @@ namespace INTV.LtoFlash.Model
                 UniqueId = uniqueId;
                 try
                 {
-                    // This is the simplistic way we "remember" which LTO Flash! devices have been connected.
-                    var deviceDirectory = Configuration.Instance.GetDeviceDataAreaPath(uniqueId);
-                    var directoryInfo = System.IO.Directory.CreateDirectory(deviceDirectory);
-                    DebugOutput("Directory: " + deviceDirectory + " created: " + directoryInfo.Exists);
+                    Configuration.Instance.RecordDeviceArrival(uniqueId);
                 }
                 catch (Exception)
                 {

--- a/INTV.LtoFlash/ViewModel/LtoFlashViewModel.cs
+++ b/INTV.LtoFlash/ViewModel/LtoFlashViewModel.cs
@@ -187,6 +187,14 @@ namespace INTV.LtoFlash.ViewModel
             get { return ComponentId; }
         }
 
+        /// <summary>
+        /// Gets the attached peripherals.
+        /// </summary>
+        public IEnumerable<IPeripheral> AttachedPeripherals
+        {
+            get { return ActiveLtoFlashDevices.Select(vm => vm.Device).Where(m => m.IsValid); }
+        }
+
         #endregion // IPrimaryComponent Properties
 
         /// <summary>
@@ -335,14 +343,6 @@ namespace INTV.LtoFlash.ViewModel
         /// </summary>
         [System.ComponentModel.Composition.ImportMany(typeof(IConnectionSharingPolicy))]
         public IEnumerable<System.Lazy<IConnectionSharingPolicy>> ConnectionSharingPolicies { get; set; }
-
-        /// <summary>
-        /// Gets the attached peripherals.
-        /// </summary>
-        internal IEnumerable<IPeripheral> AttachedPeripherals
-        {
-            get { return ActiveLtoFlashDevices.Select(vm => vm.Device).Where(m => m.IsValid); }
-        }
 
         private bool SelectionDialogShowing { get; set; }
 

--- a/INTV.Shared/ComponentModel/IPrimaryComponent.cs
+++ b/INTV.Shared/ComponentModel/IPrimaryComponent.cs
@@ -19,6 +19,7 @@
 // </copyright>
 
 using System.Collections.Generic;
+using INTV.Core.Model.Device;
 using INTV.Shared.View;
 
 namespace INTV.Shared.ComponentModel
@@ -33,6 +34,12 @@ namespace INTV.Shared.ComponentModel
         /// Gets the unique identifier of the component.
         /// </summary>
         string UniqueId { get; }
+
+        /// <summary>
+        /// Gets an enumerable of the currently attached peripherals that the component is aware of.
+        /// </summary>
+        /// <remarks>Callers should not cache this value! It does not provide a way to be informed of peripheral arrivals or departures!</remarks>
+        IEnumerable<IPeripheral> AttachedPeripherals { get; }
 
         /// <summary>
         /// Components that have any post-construction initialization should implement it in this method.

--- a/INTV.Shared/Utility/SingleInstanceApplication.cs
+++ b/INTV.Shared/Utility/SingleInstanceApplication.cs
@@ -172,7 +172,11 @@ namespace INTV.Shared.Utility
 
         // UNDONE One day, perhaps we can get these via MEF. Not ready yet, though.
         // [System.ComponentModel.Composition.ImportMany]
-        // public IEnumerable<Lazy<IPrimaryComponent>> Components;
+        // public IEnumerable<Lazy<IPrimaryComponent>> Components
+        public IEnumerable<IPrimaryComponent> Components
+        {
+            get { return CompositionHelpers.Container.GetExportedValues<IPrimaryComponent>(); }
+        }
 
         /// <summary>
         /// Gets the ROM list.
@@ -231,6 +235,12 @@ namespace INTV.Shared.Utility
         {
             var configuration = Configurations.Select(c => c.Value).OfType<T>().FirstOrDefault();
             return configuration;
+        }
+
+        public IEnumerable<IPeripheral> GetAttachedDevices()
+        {
+            var attachedDevices = Components.SelectMany(c => c.AttachedPeripherals);
+            return attachedDevices;
         }
 
         /// <summary>

--- a/INTV.Shared/ViewModel/ProgramDescriptionViewModel.cs
+++ b/INTV.Shared/ViewModel/ProgramDescriptionViewModel.cs
@@ -116,7 +116,7 @@ namespace INTV.Shared.ViewModel
                 try
                 {
 #endif // REPORT_PERFORMANCE
-                ProgramDescription.Validate(programDescription, null, null, false);
+                ProgramDescription.Validate(programDescription, SingleInstanceApplication.Instance.GetAttachedDevices(), SingleInstanceApplication.Instance.GetConnectedDevicesHistory(), reportMessagesChanged: false);
 #if REPORT_PERFORMANCE
                 }
                 finally

--- a/INTV.Shared/ViewModel/RomListViewModel.cs
+++ b/INTV.Shared/ViewModel/RomListViewModel.cs
@@ -198,6 +198,28 @@ namespace INTV.Shared.ViewModel
             get { return ComponentId; }
         }
 
+        /// <inheritdoc/>
+        public IEnumerable<IPeripheral> AttachedPeripherals
+        {
+            get
+            {
+                lock (_peripherals)
+                {
+                    var peripherals = new List<IPeripheral>();
+                    _peripherals.RemoveAll(p => !p.IsAlive);
+                    foreach (var weakPeripheralReference in _peripherals)
+                    {
+                        var peripheral = weakPeripheralReference.Target as IPeripheral;
+                        if (weakPeripheralReference.IsAlive && (peripheral != null))
+                        {
+                            peripherals.Add(peripheral);
+                        }
+                    }
+                    return peripherals;
+                }
+            }
+        }
+
         #endregion // IPrimaryComponent Properties
 
         #region Commands
@@ -222,30 +244,6 @@ namespace INTV.Shared.ViewModel
             private set { AssignAndUpdateProperty("Model", value, ref _programDescriptions, (s, p) => _programs = new ObservableViewModelCollection<ProgramDescriptionViewModel, ProgramDescription>(p, Factory, null)); }
         }
         private ProgramCollection _programDescriptions;
-
-        /// <summary>
-        /// Gets the attached peripherals.
-        /// </summary>
-        internal IEnumerable<IPeripheral> AttachedPeripherals
-        {
-            get
-            {
-                lock (_peripherals)
-                {
-                    var peripherals = new List<IPeripheral>();
-                    _peripherals.RemoveAll(p => !p.IsAlive);
-                    foreach (var weakPeripheralReference in _peripherals)
-                    {
-                        var peripheral = weakPeripheralReference.Target as IPeripheral;
-                        if (weakPeripheralReference.IsAlive && (peripheral != null))
-                        {
-                            peripherals.Add(peripheral);
-                        }
-                    }
-                    return peripherals;
-                }
-            }
-        }
 
         #endregion // Properties
 


### PR DESCRIPTION
Device history wasn't being consistently accessed or initialized. This being done incorrectly was causing some status icons to be wrong temporarily, or in certain conditions.