### PR TITLE
Remove device name from MenuLayout

### DIFF
--- a/INTV.LtoFlash/View/MenuLayoutView.Gtk.cs
+++ b/INTV.LtoFlash/View/MenuLayoutView.Gtk.cs
@@ -47,7 +47,6 @@ namespace INTV.LtoFlash.View
         ////private static readonly Dictionary<string, Gdk.Pixbuf> _deleteButtonIcons = new Dictionary<string, Gdk.Pixbuf>();
 
         private DeviceViewModel _activeDevice;
-        private TextCellInPlaceEditor _deviceNameEditor;
         private TextCellInPlaceEditor _longNameEditor;
         private TextCellInPlaceEditor _shortNameEditor;
 
@@ -59,9 +58,6 @@ namespace INTV.LtoFlash.View
             this.Build();
 
             _menuLayoutTitle.Text = MenuLayoutViewModel.Title;
-
-            _deviceName.CanDefault = false;
-            _deviceNameEditor = new TextCellInPlaceEditor(_deviceName, FileSystemConstants.MaxShortNameLength) { IsValidCharacter = INTV.Core.Model.Grom.Characters.Contains };
 
             _dirtyIcon.NoShowAll = true;
             _dirtyIcon.Visible = viewModel.ShowFileSystemsDifferIcon;
@@ -247,32 +243,6 @@ namespace INTV.LtoFlash.View
         {
             var ltoFlashViewModel = DataContext as LtoFlashViewModel;
             _newFolder.Sensitive = MenuLayoutCommandGroup.NewDirectoryCommand.CanExecute(ltoFlashViewModel.HostPCMenuLayout);
-        }
-
-        private void HandleDeviceNameTextInserted(object o, Gtk.TextInsertedArgs args)
-        {
-            var entry = o as Gtk.Entry;
-            System.Diagnostics.Debug.Assert(object.ReferenceEquals(entry, _deviceName));
-            entry.TextInserted -= HandleDeviceNameTextInserted;
-            var a = entry.Action;
-            var position = args.Position;
-            var currentText = entry.Text;
-            foreach (var character in args.Text)
-            {
-                if (!INTV.Core.Model.Grom.Characters.Contains(character))
-                {
-                    var index = currentText.IndexOf(character);
-                    while (index >= 0)
-                    {
-                        entry.DeleteText(index,index + 1);
-                        args.Position = args.Position - 1;
-                        currentText = entry.Text;
-                        index = currentText.IndexOf(character);
-                    }
-                }
-            }
-
-            entry.TextInserted += HandleDeviceNameTextInserted;
         }
 
         private void InitializeColorComboBox(Gtk.ComboBox colorChooser, ObservableCollection<FileNodeColorViewModel> colors, MenuLayoutViewModel dataContext)
@@ -574,26 +544,6 @@ namespace INTV.LtoFlash.View
 
         private void UpdateActiveDeviceViewModelInfo(DeviceViewModel device)
         {
-            // TODO: Hook this stuff up correctly for device, etc.
-            // Make not editable unless device connected
-            var editable = false;
-            var deviceNameText = device.Name;
-            if (!device.IsValid)
-            {
-                var ltoFlashViewModel = DataContext as LtoFlashViewModel;
-                deviceNameText = ltoFlashViewModel.HostPCMenuLayout.ShortName;
-                if (string.IsNullOrEmpty(deviceNameText))
-                {
-                    deviceNameText = ltoFlashViewModel.HostPCMenuLayout.LongName;
-                }
-            }
-            else
-            {
-                editable = device.IsConfigurable;
-            }
-            _deviceName.Text = deviceNameText;
-            _deviceName.IsEditable = editable;
-            _deviceName.TooltipText = deviceNameText;
         }
 
         private void HandleDeleteSelectedItems()

--- a/INTV.LtoFlash/gtk-gui/INTV.LtoFlash.View.MenuLayoutView.cs
+++ b/INTV.LtoFlash/gtk-gui/INTV.LtoFlash.View.MenuLayoutView.cs
@@ -12,10 +12,6 @@ namespace INTV.LtoFlash.View
 		
 		private global::Gtk.VSeparator vseparator1;
 		
-		private global::Gtk.Entry _deviceName;
-		
-		private global::Gtk.VSeparator vseparator2;
-		
 		private global::Gtk.Label _rootDirectoryUsage;
 		
 		private global::Gtk.Image _dirtyIcon;
@@ -72,87 +68,69 @@ namespace INTV.LtoFlash.View
 			w2.Expand = false;
 			w2.Fill = false;
 			// Container child hbox1.Gtk.Box+BoxChild
-			this._deviceName = new global::Gtk.Entry ();
-			this._deviceName.CanFocus = true;
-			this._deviceName.Name = "_deviceName";
-			this._deviceName.IsEditable = true;
-			this._deviceName.InvisibleChar = '•';
-			this.hbox1.Add (this._deviceName);
-			global::Gtk.Box.BoxChild w3 = ((global::Gtk.Box.BoxChild)(this.hbox1 [this._deviceName]));
-			w3.Position = 2;
-			// Container child hbox1.Gtk.Box+BoxChild
-			this.vseparator2 = new global::Gtk.VSeparator ();
-			this.vseparator2.Name = "vseparator2";
-			this.hbox1.Add (this.vseparator2);
-			global::Gtk.Box.BoxChild w4 = ((global::Gtk.Box.BoxChild)(this.hbox1 [this.vseparator2]));
-			w4.Position = 3;
-			w4.Expand = false;
-			w4.Fill = false;
-			// Container child hbox1.Gtk.Box+BoxChild
 			this._rootDirectoryUsage = new global::Gtk.Label ();
 			this._rootDirectoryUsage.Name = "_rootDirectoryUsage";
+			this._rootDirectoryUsage.Xalign = 0F;
 			this._rootDirectoryUsage.LabelProp = global::Mono.Unix.Catalog.GetString ("label2");
 			this.hbox1.Add (this._rootDirectoryUsage);
-			global::Gtk.Box.BoxChild w5 = ((global::Gtk.Box.BoxChild)(this.hbox1 [this._rootDirectoryUsage]));
-			w5.Position = 4;
-			w5.Expand = false;
-			w5.Fill = false;
+			global::Gtk.Box.BoxChild w3 = ((global::Gtk.Box.BoxChild)(this.hbox1 [this._rootDirectoryUsage]));
+			w3.Position = 2;
 			// Container child hbox1.Gtk.Box+BoxChild
 			this._dirtyIcon = new global::Gtk.Image ();
 			this._dirtyIcon.Name = "_dirtyIcon";
 			this.hbox1.Add (this._dirtyIcon);
-			global::Gtk.Box.BoxChild w6 = ((global::Gtk.Box.BoxChild)(this.hbox1 [this._dirtyIcon]));
-			w6.Position = 5;
-			w6.Expand = false;
-			w6.Fill = false;
+			global::Gtk.Box.BoxChild w4 = ((global::Gtk.Box.BoxChild)(this.hbox1 [this._dirtyIcon]));
+			w4.Position = 5;
+			w4.Expand = false;
+			w4.Fill = false;
 			// Container child hbox1.Gtk.Box+BoxChild
 			this._powerIcon = new global::Gtk.Image ();
 			this._powerIcon.Name = "_powerIcon";
 			this.hbox1.Add (this._powerIcon);
-			global::Gtk.Box.BoxChild w7 = ((global::Gtk.Box.BoxChild)(this.hbox1 [this._powerIcon]));
-			w7.Position = 6;
-			w7.Expand = false;
-			w7.Fill = false;
+			global::Gtk.Box.BoxChild w5 = ((global::Gtk.Box.BoxChild)(this.hbox1 [this._powerIcon]));
+			w5.Position = 6;
+			w5.Expand = false;
+			w5.Fill = false;
 			// Container child hbox1.Gtk.Box+BoxChild
 			this._newFolder = new global::Gtk.Button ();
 			this._newFolder.CanFocus = true;
 			this._newFolder.Name = "_newFolder";
 			this._newFolder.UseUnderline = true;
 			this._newFolder.FocusOnClick = false;
-			global::Gtk.Image w8 = new global::Gtk.Image ();
-			this._newFolder.Image = w8;
+			global::Gtk.Image w6 = new global::Gtk.Image ();
+			this._newFolder.Image = w6;
 			this.hbox1.Add (this._newFolder);
-			global::Gtk.Box.BoxChild w9 = ((global::Gtk.Box.BoxChild)(this.hbox1 [this._newFolder]));
-			w9.Position = 7;
-			w9.Expand = false;
-			w9.Fill = false;
+			global::Gtk.Box.BoxChild w7 = ((global::Gtk.Box.BoxChild)(this.hbox1 [this._newFolder]));
+			w7.Position = 7;
+			w7.Expand = false;
+			w7.Fill = false;
 			// Container child hbox1.Gtk.Box+BoxChild
 			this._deleteSelectedItems = new global::Gtk.Button ();
 			this._deleteSelectedItems.CanFocus = true;
 			this._deleteSelectedItems.Name = "_deleteSelectedItems";
 			this._deleteSelectedItems.UseUnderline = true;
 			this._deleteSelectedItems.FocusOnClick = false;
-			global::Gtk.Image w10 = new global::Gtk.Image ();
-			this._deleteSelectedItems.Image = w10;
+			global::Gtk.Image w8 = new global::Gtk.Image ();
+			this._deleteSelectedItems.Image = w8;
 			this.hbox1.Add (this._deleteSelectedItems);
-			global::Gtk.Box.BoxChild w11 = ((global::Gtk.Box.BoxChild)(this.hbox1 [this._deleteSelectedItems]));
-			w11.Position = 8;
-			w11.Expand = false;
-			w11.Fill = false;
+			global::Gtk.Box.BoxChild w9 = ((global::Gtk.Box.BoxChild)(this.hbox1 [this._deleteSelectedItems]));
+			w9.Position = 8;
+			w9.Expand = false;
+			w9.Fill = false;
 			// Container child hbox1.Gtk.Box+BoxChild
 			this._colorChooser = new global::Gtk.ComboBox ();
 			this._colorChooser.Name = "_colorChooser";
 			this.hbox1.Add (this._colorChooser);
-			global::Gtk.Box.BoxChild w12 = ((global::Gtk.Box.BoxChild)(this.hbox1 [this._colorChooser]));
-			w12.PackType = ((global::Gtk.PackType)(1));
-			w12.Position = 9;
-			w12.Expand = false;
-			w12.Fill = false;
+			global::Gtk.Box.BoxChild w10 = ((global::Gtk.Box.BoxChild)(this.hbox1 [this._colorChooser]));
+			w10.PackType = ((global::Gtk.PackType)(1));
+			w10.Position = 9;
+			w10.Expand = false;
+			w10.Fill = false;
 			this.vbox1.Add (this.hbox1);
-			global::Gtk.Box.BoxChild w13 = ((global::Gtk.Box.BoxChild)(this.vbox1 [this.hbox1]));
-			w13.Position = 0;
-			w13.Expand = false;
-			w13.Fill = false;
+			global::Gtk.Box.BoxChild w11 = ((global::Gtk.Box.BoxChild)(this.vbox1 [this.hbox1]));
+			w11.Position = 0;
+			w11.Expand = false;
+			w11.Fill = false;
 			// Container child vbox1.Gtk.Box+BoxChild
 			this.vpaned1 = new global::Gtk.VPaned ();
 			this.vpaned1.Name = "vpaned1";
@@ -167,11 +145,11 @@ namespace INTV.LtoFlash.View
 			this._menuLayout.Name = "_menuLayout";
 			this.GtkScrolledWindow.Add (this._menuLayout);
 			this.vpaned1.Add (this.GtkScrolledWindow);
-			global::Gtk.Paned.PanedChild w15 = ((global::Gtk.Paned.PanedChild)(this.vpaned1 [this.GtkScrolledWindow]));
-			w15.Resize = false;
+			global::Gtk.Paned.PanedChild w13 = ((global::Gtk.Paned.PanedChild)(this.vpaned1 [this.GtkScrolledWindow]));
+			w13.Resize = false;
 			this.vbox1.Add (this.vpaned1);
-			global::Gtk.Box.BoxChild w16 = ((global::Gtk.Box.BoxChild)(this.vbox1 [this.vpaned1]));
-			w16.Position = 1;
+			global::Gtk.Box.BoxChild w14 = ((global::Gtk.Box.BoxChild)(this.vbox1 [this.vpaned1]));
+			w14.Position = 1;
 			// Container child vbox1.Gtk.Box+BoxChild
 			this.hbox3 = new global::Gtk.HBox ();
 			this.hbox3.Name = "hbox3";
@@ -181,21 +159,21 @@ namespace INTV.LtoFlash.View
 			this._storageUsedLabel.Name = "_storageUsedLabel";
 			this._storageUsedLabel.LabelProp = global::Mono.Unix.Catalog.GetString ("Storage Used:");
 			this.hbox3.Add (this._storageUsedLabel);
-			global::Gtk.Box.BoxChild w17 = ((global::Gtk.Box.BoxChild)(this.hbox3 [this._storageUsedLabel]));
-			w17.Position = 0;
-			w17.Expand = false;
-			w17.Fill = false;
+			global::Gtk.Box.BoxChild w15 = ((global::Gtk.Box.BoxChild)(this.hbox3 [this._storageUsedLabel]));
+			w15.Position = 0;
+			w15.Expand = false;
+			w15.Fill = false;
 			// Container child hbox3.Gtk.Box+BoxChild
 			this._storageUsed = new global::Gtk.ProgressBar ();
 			this._storageUsed.Name = "_storageUsed";
 			this.hbox3.Add (this._storageUsed);
-			global::Gtk.Box.BoxChild w18 = ((global::Gtk.Box.BoxChild)(this.hbox3 [this._storageUsed]));
-			w18.Position = 1;
+			global::Gtk.Box.BoxChild w16 = ((global::Gtk.Box.BoxChild)(this.hbox3 [this._storageUsed]));
+			w16.Position = 1;
 			this.vbox1.Add (this.hbox3);
-			global::Gtk.Box.BoxChild w19 = ((global::Gtk.Box.BoxChild)(this.vbox1 [this.hbox3]));
-			w19.Position = 2;
-			w19.Expand = false;
-			w19.Fill = false;
+			global::Gtk.Box.BoxChild w17 = ((global::Gtk.Box.BoxChild)(this.vbox1 [this.hbox3]));
+			w17.Position = 2;
+			w17.Expand = false;
+			w17.Fill = false;
 			this.Add (this.vbox1);
 			if ((this.Child != null)) {
 				this.Child.ShowAll ();

--- a/INTV.LtoFlash/gtk-gui/gui.stetic
+++ b/INTV.LtoFlash/gtk-gui/gui.stetic
@@ -44,39 +44,23 @@
               </packing>
             </child>
             <child>
-              <widget class="Gtk.Entry" id="_deviceName">
+              <widget class="Gtk.Label" id="_rootDirectoryUsage">
                 <property name="MemberName" />
-                <property name="CanFocus">True</property>
-                <property name="IsEditable">True</property>
-                <property name="InvisibleChar">•</property>
+                <property name="Xalign">0</property>
+                <property name="LabelProp" translatable="yes">label2</property>
               </widget>
               <packing>
                 <property name="Position">2</property>
                 <property name="AutoSize">True</property>
-              </packing>
-            </child>
-            <child>
-              <widget class="Gtk.VSeparator" id="vseparator2">
-                <property name="MemberName" />
-              </widget>
-              <packing>
-                <property name="Position">3</property>
-                <property name="AutoSize">True</property>
                 <property name="Expand">False</property>
                 <property name="Fill">False</property>
               </packing>
             </child>
             <child>
-              <widget class="Gtk.Label" id="_rootDirectoryUsage">
-                <property name="MemberName" />
-                <property name="LabelProp" translatable="yes">label2</property>
-              </widget>
-              <packing>
-                <property name="Position">4</property>
-                <property name="AutoSize">True</property>
-                <property name="Expand">False</property>
-                <property name="Fill">False</property>
-              </packing>
+              <placeholder />
+            </child>
+            <child>
+              <placeholder />
             </child>
             <child>
               <widget class="Gtk.Image" id="_dirtyIcon">


### PR DESCRIPTION
The connected device's name / name of the root node in the menu tree don't make sense in the menu layout visual. This has been removed in Mac and Windows. Now, it's removed in GTK, too.