### PR TITLE
Fix GetAttachedDevices

### DIFF
--- a/INTV.Shared/Utility/SingleInstanceApplication.cs
+++ b/INTV.Shared/Utility/SingleInstanceApplication.cs
@@ -239,7 +239,11 @@ namespace INTV.Shared.Utility
 
         public IEnumerable<IPeripheral> GetAttachedDevices()
         {
-            var attachedDevices = Components.SelectMany(c => c.AttachedPeripherals);
+            var attachedDevices = Enumerable.Empty<IPeripheral>();
+            if (ReadyState == AppReadyState.Ready)
+            {
+                attachedDevices = Components.SelectMany(c => c.AttachedPeripherals);
+            }
             return attachedDevices;
         }
 


### PR DESCRIPTION
The GTK build actually uses MEF to create the UI. Because of that, the way GetAttachedDevices was implemented caused a stack overflow. (Infinite recursion.) To fix, don't interrogate the components for their attached devices until the application has finished launching.