### PR TITLE
Event handler cleanup

### DIFF
--- a/INTV.LtoFlash/View/DeviceInformation.Gtk.cs
+++ b/INTV.LtoFlash/View/DeviceInformation.Gtk.cs
@@ -126,8 +126,7 @@ namespace INTV.LtoFlash.View
 
         private void HandleViewModelPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            ////this.HandleEventOnMainThread(sender, e, HandleViewModelPropertyChangedCore);
-            HandleViewModelPropertyChangedCore(sender, e);
+            this.HandleEventOnMainThread(sender, e, HandleViewModelPropertyChangedCore);
         }
 
         private void HandleViewModelPropertyChangedCore(object sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -144,8 +143,7 @@ namespace INTV.LtoFlash.View
 
         private void HandleDevicePropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            ////this.HandleEventOnMainThread(sender, e, HandleDevicePropertyChangedCore);
-            HandleDevicePropertyChangedCore(sender, e);
+            this.HandleEventOnMainThread(sender, e, HandleDevicePropertyChangedCore);
         }
 
         private void HandleDevicePropertyChangedCore(object sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/INTV.LtoFlash/View/MenuLayoutView.Gtk.cs
+++ b/INTV.LtoFlash/View/MenuLayoutView.Gtk.cs
@@ -24,11 +24,10 @@ using System.ComponentModel;
 using System.Linq;
 using INTV.Core.Model.Stic;
 using INTV.LtoFlash.Commands;
+using INTV.LtoFlash.Model;
 using INTV.LtoFlash.ViewModel;
-using INTV.Shared.Commands;
 using INTV.Shared.Utility;
 using INTV.Shared.View;
-using INTV.LtoFlash.Model;
 using INTV.Shared.ViewModel;
 
 namespace INTV.LtoFlash.View
@@ -41,9 +40,9 @@ namespace INTV.LtoFlash.View
     [Gtk.Binding(Gdk.Key.BackSpace, "HandleDeleteSelectedItems")]
     public partial class MenuLayoutView : Gtk.Bin, IFakeDependencyObject
     {
-        private static readonly OSImage _powerIconImage = typeof(INTV.Shared.Utility.ResourceHelpers).LoadImageResource("ViewModel/Resources/Images/console_16xLG.png");
-        private static readonly OSImage _dirtyIconImage = typeof(MenuLayoutView).LoadImageResource("Resources/Images/lto_flash_contents_not_in_sync_16xLG.png");
-        private static readonly Dictionary<Color, Gdk.Pixbuf> _colorPixbufs = new Dictionary<Color, Gdk.Pixbuf>();
+        private static readonly OSImage PowerIconImage = typeof(INTV.Shared.Utility.ResourceHelpers).LoadImageResource("ViewModel/Resources/Images/console_16xLG.png");
+        private static readonly OSImage DirtyIconImage = typeof(MenuLayoutView).LoadImageResource("Resources/Images/lto_flash_contents_not_in_sync_16xLG.png");
+        private static readonly Dictionary<Color, Gdk.Pixbuf> ColorPixbufs = new Dictionary<Color, Gdk.Pixbuf>();
         ////private static readonly Dictionary<string, Gdk.Pixbuf> _deleteButtonIcons = new Dictionary<string, Gdk.Pixbuf>();
 
         private DeviceViewModel _activeDevice;
@@ -61,9 +60,9 @@ namespace INTV.LtoFlash.View
 
             _dirtyIcon.NoShowAll = true;
             _dirtyIcon.Visible = viewModel.ShowFileSystemsDifferIcon;
-            _dirtyIcon.Pixbuf = _dirtyIconImage;
+            _dirtyIcon.Pixbuf = DirtyIconImage;
             _dirtyIcon.TooltipText = LtoFlashViewModel.ContentsNotInSyncToolTip;
-            _powerIcon.Pixbuf = _powerIconImage.CreateNewWithOpacity(0.5); // initialize to the "power off" image
+            _powerIcon.Pixbuf = PowerIconImage.CreateNewWithOpacity(0.5); // initialize to the "power off" image
             _powerIcon.TooltipText = Resources.Strings.ConsolePowerState_Unknown;
 
             ((Gtk.Image)_newFolder.Image).Pixbuf = MenuLayoutCommandGroup.NewDirectoryCommand.SmallIcon;
@@ -224,6 +223,7 @@ namespace INTV.LtoFlash.View
             if ((comboBox.Active != currentItemColorIndex) && (comboBox.Active >= 0))
             {
                 var newColor = viewModel.AvailableColors[comboBox.Active];
+
                 // TODO: Verify behavior for multi-select
                 foreach (var file in viewModel.SelectedItems)
                 {
@@ -257,16 +257,16 @@ namespace INTV.LtoFlash.View
                 var pixbuf = new Gdk.Pixbuf(Gdk.Colorspace.Rgb, true, 8, 16, 16);
                 pixbuf.Fill(0xFF); // black background
                 pixbufColor.CopyArea(0, 0, 14, 14, pixbuf, 1, 1);
-                _colorPixbufs[color.IntvColor] = pixbuf;
+                ColorPixbufs[color.IntvColor] = pixbuf;
             }
 
             Gtk.CellRenderer cellRenderer = new Gtk.CellRendererPixbuf() { Xalign = 0 };
             colorChooser.PackStart(cellRenderer, false);
-            colorChooser.SetCellDataFunc(cellRenderer, (l,e,m,i) => VisualHelpers.CellImageRenderer<FileNodeColorViewModel>(l,e,m,i, c => _colorPixbufs[c.IntvColor]));
+            colorChooser.SetCellDataFunc(cellRenderer, (l, e, m, i) => VisualHelpers.CellImageRenderer<FileNodeColorViewModel>(l, e, m, i, c => ColorPixbufs[c.IntvColor]));
 
             cellRenderer = new Gtk.CellRendererCombo() { Xalign = 0, Xpad = 4 };
             colorChooser.PackEnd(cellRenderer, true);
-            colorChooser.SetCellDataFunc(cellRenderer, (l,e,m,i) => VisualHelpers.CellTextRenderer<FileNodeColorViewModel>(l,e,m,i, c=> c.Name));
+            colorChooser.SetCellDataFunc(cellRenderer, (l, e, m, i) => VisualHelpers.CellTextRenderer<FileNodeColorViewModel>(l, e, m, i, c => c.Name));
 
             var colorListStore = new Gtk.ListStore(typeof(FileNodeColorViewModel));
             colorListStore.SynchronizeCollection(colors);
@@ -289,9 +289,9 @@ namespace INTV.LtoFlash.View
 
             Gtk.CellRenderer cellRenderer = new Gtk.CellRendererPixbuf();
             column.PackStart(cellRenderer, true);
-            column.SetCellDataFunc(cellRenderer, (l,c,m,i) => VisualHelpers.CellImageColumnRenderer<FileNodeViewModel>(l,c,m,i, p => p.Icon));
-            //column.Sizing = Gtk.TreeViewColumnSizing.Fixed;
-            //column.FixedWidth = 20;
+            column.SetCellDataFunc(cellRenderer, (l, c, m, i) => VisualHelpers.CellImageColumnRenderer<FileNodeViewModel>(l, c, m, i, p => p.Icon));
+            ////column.Sizing = Gtk.TreeViewColumnSizing.Fixed;
+            ////column.FixedWidth = 20;
             menuLayout.AppendColumn(column);
 
             column = new Gtk.TreeViewColumn() { Title = MenuLayoutViewModel.LongNameHeader };
@@ -299,7 +299,7 @@ namespace INTV.LtoFlash.View
             _longNameEditor = new TextCellInPlaceEditor(menuLayout, column, cellRenderer as Gtk.CellRendererText, FileSystemConstants.MaxLongNameLength) { IsValidCharacter = INTV.Core.Model.Grom.Characters.Contains };
             _longNameEditor.EditorClosed += HandleInPlaceEditorClosed;
             column.PackStart(cellRenderer, true);
-            column.SetCellDataFunc(cellRenderer, (l,c,m,i) => VisualHelpers.CellTextColumnRenderer<FileNodeViewModel>(l,c,m,i, p => p.LongName.SafeString()));
+            column.SetCellDataFunc(cellRenderer, (l, c, m, i) => VisualHelpers.CellTextColumnRenderer<FileNodeViewModel>(l, c, m, i, p => p.LongName.SafeString()));
             column.Sizing = Gtk.TreeViewColumnSizing.Fixed;
             column.FixedWidth = Properties.Settings.Default.MenuLayoutLongNameColWidth;
             column.Resizable = true;
@@ -310,7 +310,7 @@ namespace INTV.LtoFlash.View
             _shortNameEditor = new TextCellInPlaceEditor(menuLayout, column, cellRenderer as Gtk.CellRendererText, FileSystemConstants.MaxShortNameLength) { IsValidCharacter = INTV.Core.Model.Grom.Characters.Contains };
             _shortNameEditor.EditorClosed += HandleInPlaceEditorClosed;
             column.PackStart(cellRenderer, true);
-            column.SetCellDataFunc(cellRenderer, (l,c,m,i) => VisualHelpers.CellTextColumnRenderer<FileNodeViewModel>(l,c,m,i, p => p.ShortName.SafeString()));
+            column.SetCellDataFunc(cellRenderer, (l, c, m, i) => VisualHelpers.CellTextColumnRenderer<FileNodeViewModel>(l, c, m, i, p => p.ShortName.SafeString()));
             column.Sizing = Gtk.TreeViewColumnSizing.Fixed;
             column.FixedWidth = Properties.Settings.Default.MenuLayoutShortNameColWidth;
             column.Resizable = true;
@@ -319,7 +319,7 @@ namespace INTV.LtoFlash.View
             column = new Gtk.TreeViewColumn() { Title = MenuLayoutViewModel.ManualHeader };
             cellRenderer = new Gtk.CellRendererText();
             column.PackStart(cellRenderer, true);
-            column.SetCellDataFunc(cellRenderer, (l,c,m,i) => VisualHelpers.CellTextColumnRenderer<FileNodeViewModel>(l,c,m,i, GetManualColumnStringValue));
+            column.SetCellDataFunc(cellRenderer, (l, c, m, i) => VisualHelpers.CellTextColumnRenderer<FileNodeViewModel>(l, c, m, i, GetManualColumnStringValue));
             column.Sizing = Gtk.TreeViewColumnSizing.Fixed;
             column.FixedWidth = Properties.Settings.Default.MenuLayoutManualColWidth;
             column.Resizable = true;
@@ -328,9 +328,9 @@ namespace INTV.LtoFlash.View
             column = new Gtk.TreeViewColumn() { Title = MenuLayoutViewModel.SaveDataHeader };
             cellRenderer = new Gtk.CellRendererText();
             column.PackStart(cellRenderer, true);
-            //column.SetCellDataFunc(cellRenderer, (l,c,m,i) => VisualHelpers.CellTextColumnRenderer<ProgramDescriptionViewModel>(l,c,m,i, p => p.Name));
-            //column.Sizing = Gtk.TreeViewColumnSizing.Fixed;
-            //column.FixedWidth = Properties.Settings.Default.MenuLayoutSaveDataColWidth;
+            ////column.SetCellDataFunc(cellRenderer, (l,c,m,i) => VisualHelpers.CellTextColumnRenderer<ProgramDescriptionViewModel>(l,c,m,i, p => p.Name));
+            ////column.Sizing = Gtk.TreeViewColumnSizing.Fixed;
+            ////column.FixedWidth = Properties.Settings.Default.MenuLayoutSaveDataColWidth;
             column.Resizable = true;
             column.Visible = Properties.Settings.Default.ShowAdvancedFeatures;
             menuLayout.AppendColumn(column);
@@ -347,7 +347,7 @@ namespace INTV.LtoFlash.View
             dataContext.PropertyChanged += HandleMenuLayoutPropertyChanged;
         }
 
-        private static string GetManualColumnStringValue(FileNodeViewModel node)
+        private string GetManualColumnStringValue(FileNodeViewModel node)
         {
             if (node is FolderViewModel)
             {
@@ -452,94 +452,100 @@ namespace INTV.LtoFlash.View
 
         private void HandleMenuLayoutPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            OSDispatcher.Current.InvokeOnMainDispatcher(() =>
-                {
-                    var menuLayout = sender as MenuLayoutViewModel;
-                    switch (e.PropertyName)
-                    {
-                        case MenuLayoutViewModel.StatusPropertyName:
-                            _rootDirectoryUsage.Text = menuLayout.Status;
-                            break;
-                        case MenuLayoutViewModel.CurrentSelectionPropertyName:
+            this.HandleEventOnMainThread(sender, e, HandleMenuLayoutPropertyChangedCore);
+        }
+
+        private void HandleMenuLayoutPropertyChangedCore(object sender, PropertyChangedEventArgs e)
+        {
+            var menuLayout = sender as MenuLayoutViewModel;
+            switch (e.PropertyName)
+            {
+                case MenuLayoutViewModel.StatusPropertyName:
+                    _rootDirectoryUsage.Text = menuLayout.Status;
+                    break;
+                case MenuLayoutViewModel.CurrentSelectionPropertyName:
                     // Push from ViewModel's notion of selected item to the tree's selection.
                     // TODO: what happens when multiselect is enabled?
-                            Gtk.TreeIter selectionIter;
-                            if (_menuLayout.Selection.GetSelected(out selectionIter))
+                    Gtk.TreeIter selectionIter;
+                    if (_menuLayout.Selection.GetSelected(out selectionIter))
+                    {
+                        var currentSelectedItem = menuLayout.CurrentSelection;
+                        var modelSelection = _menuLayout.Model.GetValue(selectionIter, 0);
+                        if (modelSelection != currentSelectedItem)
+                        {
+                            Gtk.TreeIter iter;
+                            if (currentSelectedItem.GetIterForItem(out iter, _menuLayout.Model as Gtk.TreeStore))
                             {
-                                var currentSelectedItem = menuLayout.CurrentSelection;
-                                var modelSelection = _menuLayout.Model.GetValue(selectionIter, 0);
-                                if (modelSelection != currentSelectedItem)
-                                {
-                                    Gtk.TreeIter iter;
-                                    if (currentSelectedItem.GetIterForItem(out iter, _menuLayout.Model as Gtk.TreeStore))
-                                    {
-                                        _menuLayout.Selection.SelectIter(iter);
-                                    }
-                                }
+                                _menuLayout.Selection.SelectIter(iter);
                             }
-                            else if (menuLayout.CurrentSelection != null)
-                            {
-                                // Don't have a selection, so find and select item from ViewModel.
-                                var currentSelectedItem = menuLayout.CurrentSelection;
-                                Gtk.TreeIter iter;
-                                if (currentSelectedItem.GetIterForItem(out iter, _menuLayout.Model as Gtk.TreeStore))
-                                {
-                                    _menuLayout.Selection.SelectIter(iter);
-                                }
-                            }
-                            INTV.Shared.ComponentModel.CommandManager.InvalidateRequerySuggested();
-                            break;
-                        case "DeleteSelectedItemTip":
-                            _deleteSelectedItems.TooltipText = menuLayout.DeleteSelectedItemTip;
-                            break;
-                        case MenuLayoutViewModel.OverallUsageDetailsPropertyName:
-                            _storageUsed.Fraction = menuLayout.OverallInUseRatio;
-                            _storageUsed.Text = string.Format("{0:P2}", _storageUsed.Fraction);
-                            _storageUsed.TooltipText = menuLayout.OverallUsageDetails;
-                            break;
-                        default:
-                            break;
+                        }
                     }
-                });
+                    else if (menuLayout.CurrentSelection != null)
+                    {
+                        // Don't have a selection, so find and select item from ViewModel.
+                        var currentSelectedItem = menuLayout.CurrentSelection;
+                        Gtk.TreeIter iter;
+                        if (currentSelectedItem.GetIterForItem(out iter, _menuLayout.Model as Gtk.TreeStore))
+                        {
+                            _menuLayout.Selection.SelectIter(iter);
+                        }
+                    }
+                    INTV.Shared.ComponentModel.CommandManager.InvalidateRequerySuggested();
+                    break;
+                case "DeleteSelectedItemTip":
+                    _deleteSelectedItems.TooltipText = menuLayout.DeleteSelectedItemTip;
+                    break;
+                case MenuLayoutViewModel.OverallUsageDetailsPropertyName:
+                    _storageUsed.Fraction = menuLayout.OverallInUseRatio;
+                    _storageUsed.Text = string.Format("{0:P2}", _storageUsed.Fraction);
+                    _storageUsed.TooltipText = menuLayout.OverallUsageDetails;
+                    break;
+                default:
+                    break;
+            }
         }
 
         private void HandleLtoFlashPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            OSDispatcher.Current.InvokeOnMainDispatcher(() =>
-                {
-                    var viewModel = sender as LtoFlashViewModel;
-                    switch (e.PropertyName)
-                    {
-                        case LtoFlashViewModel.ActiveLtoFlashDevicePropertyName:
-                            _activeDevice.PropertyChanged -= HandleActiveDevicePropertyChanged;
-                            _activeDevice = viewModel.ActiveLtoFlashDevice;
-                            _activeDevice.PropertyChanged += HandleActiveDevicePropertyChanged;
-                            UpdateActiveDeviceViewModelInfo(viewModel.ActiveLtoFlashDevice);
-                            break;
-                        case LtoFlashViewModel.ShowFileSystemsDifferIconPropertyName:
-                            _dirtyIcon.Visible = viewModel.ShowFileSystemsDifferIcon;
-                            break;
-                        default:
-                            break;
-                    }
-                });
+            this.HandleEventOnMainThread(sender, e, HandleLtoFlashPropertyChangedCore);
+        }
+
+        private void HandleLtoFlashPropertyChangedCore(object sender, PropertyChangedEventArgs e)
+        {
+            var viewModel = sender as LtoFlashViewModel;
+            switch (e.PropertyName)
+            {
+                case LtoFlashViewModel.ActiveLtoFlashDevicePropertyName:
+                    _activeDevice.PropertyChanged -= HandleActiveDevicePropertyChanged;
+                    _activeDevice = viewModel.ActiveLtoFlashDevice;
+                    _activeDevice.PropertyChanged += HandleActiveDevicePropertyChanged;
+                    UpdateActiveDeviceViewModelInfo(viewModel.ActiveLtoFlashDevice);
+                    break;
+                case LtoFlashViewModel.ShowFileSystemsDifferIconPropertyName:
+                    _dirtyIcon.Visible = viewModel.ShowFileSystemsDifferIcon;
+                    break;
+                default:
+                    break;
+            }
         }
 
         private void HandleActiveDevicePropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            OSDispatcher.Current.InvokeOnMainDispatcher(() =>
-                {
-                    var device = sender as DeviceViewModel;
-                    switch (e.PropertyName)
-                    {
-                        case DeviceViewModel.IsConfigurablePropertyName:
-                        case Device.IsValidPropertyName:
-                            UpdateActiveDeviceViewModelInfo(device);
-                            break;
-                        default:
-                            break;
-                    }
-                });
+            this.HandleEventOnMainThread(sender, e, HandleActiveDevicePropertyChangedCore);
+        }
+
+        private void HandleActiveDevicePropertyChangedCore(object sender, PropertyChangedEventArgs e)
+        {
+            var device = sender as DeviceViewModel;
+            switch (e.PropertyName)
+            {
+                case DeviceViewModel.IsConfigurablePropertyName:
+                case Device.IsValidPropertyName:
+                    UpdateActiveDeviceViewModelInfo(device);
+                    break;
+                default:
+                    break;
+            }
         }
 
         private void UpdateActiveDeviceViewModelInfo(DeviceViewModel device)

--- a/INTV.LtoFlash/View/PromptToAddMenuItemsForNewRoms.Gtk.cs
+++ b/INTV.LtoFlash/View/PromptToAddMenuItemsForNewRoms.Gtk.cs
@@ -20,9 +20,13 @@
 
 using INTV.LtoFlash.ViewModel;
 using INTV.Shared.Utility;
+using INTV.Shared.View;
 
 namespace INTV.LtoFlash.View
 {
+    /// <summary>
+    /// GTK-specific implementation.
+    /// </summary>
     public partial class PromptToAddMenuItemsForNewRoms : Gtk.Dialog
     {
         private PromptToAddMenuItemsForNewRoms()
@@ -64,7 +68,12 @@ namespace INTV.LtoFlash.View
             }
         }
 
-        private void HandleSettingsChanged (object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        private void HandleSettingsChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            this.HandleEventOnMainThread(sender, e, HandleSettingsChangedCore);
+        }
+
+        private void HandleSettingsChangedCore(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {

--- a/INTV.LtoFlash/View/SettingsPage.Gtk.cs
+++ b/INTV.LtoFlash/View/SettingsPage.Gtk.cs
@@ -138,6 +138,11 @@ namespace INTV.LtoFlash.View
 
         private void HandleSettingChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
+            this.HandleEventOnMainThread(sender, e, HandleSettingChangedCore);
+        }
+
+        private void HandleSettingChangedCore(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
             Gtk.CheckButton settingControl = null;
             switch (e.PropertyName)
             {

--- a/INTV.Shared/View/ReportDialog.Gtk.cs
+++ b/INTV.Shared/View/ReportDialog.Gtk.cs
@@ -48,7 +48,8 @@ namespace INTV.Shared.View
             {
                 viewModel.Message = message;
             }
-            var propertiesToUpdate = new[] {
+            var propertiesToUpdate = new[]
+                {
                 ReportDialogViewModel.TitlePropertyName,
                 ReportDialogViewModel.MessagePropertyName,
                 ReportDialogViewModel.CloseDialogButtonTextPropertyName,
@@ -59,7 +60,7 @@ namespace INTV.Shared.View
                 ReportDialogViewModel.SendEmailButtonLabelTextPropertyName,
                 ReportDialogViewModel.ShowSendEmailButtonPropertyName,
                 ReportDialogViewModel.SendEmailEnabledPropertyName,
-                //ReportDialogViewModel.EmailSenderPropertyName,
+                ////ReportDialogViewModel.EmailSenderPropertyName,
                 ReportDialogViewModel.HasAttachmentsPropertyName,
             };
             foreach (var propertyName in propertiesToUpdate)
@@ -91,6 +92,18 @@ namespace INTV.Shared.View
                 }
                 return viewModel;
             }
+        }
+
+        /// <summary>
+        /// Creates a new instance of the ReportDialog.
+        /// </summary>
+        /// <param name="title">The title for the dialog.</param>
+        /// <param name="message">The message to display in the dialog.</param>
+        /// <returns>The dialog instance.</returns>
+        public static ReportDialog Create(string title, string message)
+        {
+            var dialog = new ReportDialog(title, message);
+            return dialog;
         }
 
         #region IFakeDependencyObject Methods
@@ -126,18 +139,6 @@ namespace INTV.Shared.View
         }
 
         /// <summary>
-        /// Creates a new instance of the ReportDialog.
-        /// </summary>
-        /// <param name="title">The title for the dialog.</param>
-        /// <param name="message">The message to display in the dialog.</param>
-        /// <returns>The dialog instance.</returns>
-        public static ReportDialog Create(string title, string message)
-        {
-            var dialog = new ReportDialog(title, message);
-            return dialog;
-        }
-
-        /// <summary>
         /// Shows the dialog.
         /// </summary>
         /// <returns>A nullable value; if <c>true</c> the OK or equivalent was clicked; if <c>false</c>,
@@ -167,7 +168,12 @@ namespace INTV.Shared.View
             return result;
         }
 
-        private void HandlePropertyChanged (object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        private void HandlePropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            this.HandleEventOnMainThread(sender, e, HandlePropertyChangedCore);
+        }
+
+        private void HandlePropertyChangedCore(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {
@@ -216,12 +222,12 @@ namespace INTV.Shared.View
             }
         }
 
-        protected void HandleShowAttachedFiles (object sender, System.EventArgs e)
+        protected void HandleShowAttachedFiles(object sender, System.EventArgs e)
         {
             ReportDialogViewModel.ShowAttachmentsInFileSystemCommand.Execute(ViewModel);
         }
 
-        protected void HandleSendErrorReport (object sender, System.EventArgs e)
+        protected void HandleSendErrorReport(object sender, System.EventArgs e)
         {
 #if false // COPIED FROM MonoMac)
             if (ViewModel.ShowEmailSender)
@@ -245,7 +251,7 @@ namespace INTV.Shared.View
             ReportDialogViewModel.SendErrorReportEmailCommand.Execute(ViewModel);
         }
 
-        protected void HandleCopyToClipboard (object sender, System.EventArgs e)
+        protected void HandleCopyToClipboard(object sender, System.EventArgs e)
         {
             ReportDialogViewModel.CopyToClipboardCommand.Execute(ViewModel);
         }

--- a/INTV.Shared/View/RomListSettingsPage.Gtk.cs
+++ b/INTV.Shared/View/RomListSettingsPage.Gtk.cs
@@ -78,7 +78,7 @@ namespace INTV.Shared.View
 
         #endregion // IFakeDependencyObject
 
-        protected void HandleValidateAtLaunchToggled (object sender, System.EventArgs e)
+        protected void HandleValidateAtLaunchToggled(object sender, System.EventArgs e)
         {
             if (Properties.Settings.Default.RomListValidateAtStartup != _validateAtLaunch.Active)
             {
@@ -86,7 +86,7 @@ namespace INTV.Shared.View
             }
         }
 
-        protected void HandleSearchForRomsAtLaunchToggled (object sender, System.EventArgs e)
+        protected void HandleSearchForRomsAtLaunchToggled(object sender, System.EventArgs e)
         {
             if (Properties.Settings.Default.RomListSearchForRomsAtStartup != _searchForRomsAtLaunch.Active)
             {
@@ -94,15 +94,15 @@ namespace INTV.Shared.View
             }
         }
 
-        protected void HandleDisplayRomFileNameForTitleToggled (object sender, System.EventArgs e)
+        protected void HandleDisplayRomFileNameForTitleToggled(object sender, System.EventArgs e)
         {
-            if (Properties.Settings.Default.DisplayRomFileNameForTitle !=_displayRomFileNameForTitle.Active)
+            if (Properties.Settings.Default.DisplayRomFileNameForTitle != _displayRomFileNameForTitle.Active)
             {
-                Properties.Settings.Default.DisplayRomFileNameForTitle =_displayRomFileNameForTitle.Active;
+                Properties.Settings.Default.DisplayRomFileNameForTitle = _displayRomFileNameForTitle.Active;
             }
         }
 
-        protected void HandleShowRomDetailsToggled (object sender, System.EventArgs e)
+        protected void HandleShowRomDetailsToggled(object sender, System.EventArgs e)
         {
             if (Properties.Settings.Default.ShowRomDetails != _showRomDetails.Active)
             {
@@ -110,7 +110,12 @@ namespace INTV.Shared.View
             }
         }
 
-        private void HandleSettingChanged (object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        private void HandleSettingChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            this.HandleEventOnMainThread(sender, e, HandleSettingChangedCore);
+        }
+
+        private void HandleSettingChangedCore(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {

--- a/INTV.Shared/View/RomListView.Gtk.cs
+++ b/INTV.Shared/View/RomListView.Gtk.cs
@@ -38,11 +38,11 @@ namespace INTV.Shared.View
         /// <summary>
         /// Initializes a new instance of the <see cref="INTV.Shared.View.RomListView"/> class.
         /// </summary>
+        /// <param name="viewModel">The data context for this visual.</param>
         public RomListView(RomListViewModel viewModel)
         {
             // TODO: Set up sorting!
             // TODO: DragDrop!
-
             DataContext = viewModel;
             this.Build();
             var treeView = _romListView;
@@ -52,7 +52,7 @@ namespace INTV.Shared.View
             var column = new Gtk.TreeViewColumn();
             Gtk.CellRenderer cellRenderer = new Gtk.CellRendererPixbuf();
             column.PackStart(cellRenderer, true);
-            column.SetCellDataFunc(cellRenderer, (l,c,m,i) => VisualHelpers.CellImageColumnRenderer<ProgramDescriptionViewModel>(l,c,m,i, p => p.RomFileStatusIcon));
+            column.SetCellDataFunc(cellRenderer, (l, c, m, i) => VisualHelpers.CellImageColumnRenderer<ProgramDescriptionViewModel>(l, c, m, i, p => p.RomFileStatusIcon));
             column.Sizing = Gtk.TreeViewColumnSizing.Fixed;
             column.FixedWidth = 20;
             treeView.AppendColumn(column);
@@ -60,7 +60,7 @@ namespace INTV.Shared.View
             column = new Gtk.TreeViewColumn() { Title = RomListViewModel.TitleHeader };
             cellRenderer = new Gtk.CellRendererText();
             column.PackStart(cellRenderer, true);
-            column.SetCellDataFunc(cellRenderer, (l,c,m,i) => VisualHelpers.CellTextColumnRenderer<ProgramDescriptionViewModel>(l,c,m,i, p => p.Name));
+            column.SetCellDataFunc(cellRenderer, (l, c, m, i) => VisualHelpers.CellTextColumnRenderer<ProgramDescriptionViewModel>(l, c, m, i, p => p.Name));
             column.Sizing = Gtk.TreeViewColumnSizing.Fixed;
             column.FixedWidth = Properties.Settings.Default.RomListNameColWidth;
             column.Resizable = true;
@@ -69,7 +69,7 @@ namespace INTV.Shared.View
             column = new Gtk.TreeViewColumn() { Title = RomListViewModel.CompanyHeader };
             cellRenderer = new Gtk.CellRendererText();
             column.PackStart(cellRenderer, true);
-            column.SetCellDataFunc(cellRenderer, (l,c,m,i) => VisualHelpers.CellTextColumnRenderer<ProgramDescriptionViewModel>(l,c,m,i, p => p.Vendor));
+            column.SetCellDataFunc(cellRenderer, (l, c, m, i) => VisualHelpers.CellTextColumnRenderer<ProgramDescriptionViewModel>(l, c, m, i, p => p.Vendor));
             column.Sizing = Gtk.TreeViewColumnSizing.Fixed;
             column.FixedWidth = Properties.Settings.Default.RomListVendorColWidth;
             column.Resizable = true;
@@ -78,7 +78,7 @@ namespace INTV.Shared.View
             column = new Gtk.TreeViewColumn() { Title = RomListViewModel.YearHeader };
             cellRenderer = new Gtk.CellRendererText();
             column.PackStart(cellRenderer, true);
-            column.SetCellDataFunc(cellRenderer, (l,c,m,i) => VisualHelpers.CellTextColumnRenderer<ProgramDescriptionViewModel>(l,c,m,i, p => p.Year));
+            column.SetCellDataFunc(cellRenderer, (l, c, m, i) => VisualHelpers.CellTextColumnRenderer<ProgramDescriptionViewModel>(l, c, m, i, p => p.Year));
             column.Sizing = Gtk.TreeViewColumnSizing.Fixed;
             column.FixedWidth = Properties.Settings.Default.RomListYearColWidth;
             column.Resizable = true;
@@ -88,16 +88,16 @@ namespace INTV.Shared.View
             cellRenderer = new Gtk.CellRendererPixbuf();
             cellRenderer.Xalign = 0;
             column.PackStart(cellRenderer, true);
-            column.SetCellDataFunc(cellRenderer, (l,c,m,i) => VisualHelpers.CellImageColumnRenderer<ProgramDescriptionViewModel>(l,c,m,i, p => INTV.Shared.Converter.ProgramFeaturesToPixbufConverter.ConvertToPixbuf(p)));
+            column.SetCellDataFunc(cellRenderer, (l, c, m, i) => VisualHelpers.CellImageColumnRenderer<ProgramDescriptionViewModel>(l, c, m, i, p => INTV.Shared.Converter.ProgramFeaturesToPixbufConverter.ConvertToPixbuf(p)));
             column.Sizing = Gtk.TreeViewColumnSizing.Fixed;
             column.FixedWidth = Properties.Settings.Default.RomListFeaturesColWidth;
             column.Resizable = true;
             treeView.AppendColumn(column);
 
-            column = new Gtk.TreeViewColumn() { Title = RomListViewModel.RomFileHeader};
+            column = new Gtk.TreeViewColumn() { Title = RomListViewModel.RomFileHeader };
             cellRenderer = new Gtk.CellRendererText();
             column.PackStart(cellRenderer, true);
-            column.SetCellDataFunc(cellRenderer, (l,c,m,i) =>VisualHelpers.CellTextColumnRenderer<ProgramDescriptionViewModel>(l,c,m,i, p => p.Rom.RomPath));
+            column.SetCellDataFunc(cellRenderer, (l, c, m, i) => VisualHelpers.CellTextColumnRenderer<ProgramDescriptionViewModel>(l, c, m, i, p => p.Rom.RomPath));
             ////column.Sizing = Gtk.TreeViewColumnSizing.Fixed;
             ////column.FixedWidth = Properties.Settings.Default.RomListPathColWidth;
             column.Resizable = true;
@@ -271,6 +271,11 @@ namespace INTV.Shared.View
 
         private void HandleSettingsChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
+            this.HandleEventOnMainThread(sender, e, HandleSettingsChangedCore);
+        }
+
+        private void HandleSettingsChangedCore(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
             var show = Properties.Settings.Default.ShowRomDetails;
             switch (e.PropertyName)
             {
@@ -287,10 +292,20 @@ namespace INTV.Shared.View
 
         private void HandleProgramsChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
         {
+            this.HandleEventOnMainThread(sender, e, HandleProgramsChangedCore);
+        }
+
+        private void HandleProgramsChangedCore(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
             _romListView.Model.SynchronizeCollection<ProgramDescriptionViewModel>(e);
         }
 
         private void HandleProgramStatusChanged(object sender, INTV.Shared.Model.Program.ProgramFeaturesChangedEventArgs e)
+        {
+            this.HandleEventOnMainThread(sender, e, HandleProgramStatusChangedCore);
+        }
+
+        private void HandleProgramStatusChangedCore(object sender, INTV.Shared.Model.Program.ProgramFeaturesChangedEventArgs e)
         {
             // Need to goose the TreeView to re-draw the status icons.
             _romListView.QueueDraw();

--- a/INTV.Shared/View/SerialPortSelector.Gtk.cs
+++ b/INTV.Shared/View/SerialPortSelector.Gtk.cs
@@ -71,6 +71,7 @@ namespace INTV.Shared.View
         internal void Initialize(SerialPortSelectorViewModel viewModel)
         {
             DataContext = viewModel;
+
             // TODO: CollectionChanged handler -- see Synchronize calls
             // TODO: PropertyChanged handler
             // TODO: Handle item disabled / enabled in list -- see ShouldSelect
@@ -86,10 +87,10 @@ namespace INTV.Shared.View
             var column = new Gtk.TreeViewColumn() { Title = SerialPortSelectorViewModel.PortColumnTitle };
             var cellRenderer = new Gtk.CellRendererText();
             column.PackStart(cellRenderer, true);
-            column.SetCellDataFunc(cellRenderer, (l,c,m,i) => VisualHelpers.CellTextColumnRenderer<SerialPortViewModel>(l,c,m,i, p => p.PortName));
-//            column.Sizing = Gtk.TreeViewColumnSizing.Fixed;
-//            column.FixedWidth = Properties.Settings.Default.MenuLayoutLongNameColWidth;
-//            column.Resizable = true;
+            column.SetCellDataFunc(cellRenderer, (l, c, m, i) => VisualHelpers.CellTextColumnRenderer<SerialPortViewModel>(l, c, m, i, p => p.PortName));
+            ////column.Sizing = Gtk.TreeViewColumnSizing.Fixed;
+            ////column.FixedWidth = Properties.Settings.Default.MenuLayoutLongNameColWidth;
+            ////column.Resizable = true;
             portsList.AppendColumn(column);
 
             portsList.Selection.Changed += HandleSelectedPortChanged;
@@ -97,6 +98,7 @@ namespace INTV.Shared.View
 
             var serialPortsModel = new Gtk.ListStore(typeof(SerialPortViewModel));
             serialPortsModel.SynchronizeCollection(viewModel.AvailableSerialPorts);
+
             // TODO: Disable ports appropriately -- see ShouldSelect
             // TODO: Customize renderer somehow for disabled items to draw differently --
             // Tinkering with CellRendererText.Foreground does not work as desired.
@@ -113,8 +115,8 @@ namespace INTV.Shared.View
 
             Gtk.CellRenderer cellRenderer = new Gtk.CellRendererCombo(); // { Xalign = 0, Xpad = 4 };
             baudRates.PackStart(cellRenderer, false);
-            //            baudRates.PackEnd(cellRenderer, true);
-            baudRates.SetCellDataFunc(cellRenderer, (l,e,m,i) => VisualHelpers.CellTextRenderer<BaudRateViewModel>(l,e,m,i, c => c.BaudRate.ToString()));
+            ////baudRates.PackEnd(cellRenderer, true);
+            baudRates.SetCellDataFunc(cellRenderer, (l, e, m, i) => VisualHelpers.CellTextRenderer<BaudRateViewModel>(l, e, m, i, c => c.BaudRate.ToString()));
 
             var baudRatesModel = new Gtk.ListStore(typeof(BaudRateViewModel));
             baudRatesModel.SynchronizeCollection(viewModel.BaudRates);
@@ -157,6 +159,11 @@ namespace INTV.Shared.View
         }
 
         private void HandleAvailablePortsChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            this.HandleEventOnMainThread(sender, e, HandleAvailablePortsChangedCore);
+        }
+
+        private void HandleAvailablePortsChangedCore(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
         {
             _ports.Model.SynchronizeCollection<SerialPortViewModel>(e);
         }

--- a/INTV.Shared/View/VisualHelpers.Gtk.cs
+++ b/INTV.Shared/View/VisualHelpers.Gtk.cs
@@ -20,6 +20,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using INTV.Shared.Utility;
 
 namespace INTV.Shared.View
 {
@@ -67,6 +68,19 @@ namespace INTV.Shared.View
                 typedChild = container.Children[index] as T;
             }
             return typedChild;
+        }
+
+        /// <summary>
+        /// Ensures that an event handler is invoked on main the thread.
+        /// </summary>
+        /// <typeparam name="TEventArgs">The data type of the event handler's data.</typeparam>
+        /// <param name="instance">Typically a Gtk.Widget that must handle an event from a ViewModel.</param>
+        /// <param name="sender">Sender of the orginal event.</param>
+        /// <param name="args">Event data.</param>
+        /// <param name="handler">The event handler to ensure is executed on the main thread.</param>
+        public static void HandleEventOnMainThread<TEventArgs>(this Gtk.Widget instance, object sender, TEventArgs args, System.Action<object, TEventArgs> handler) where TEventArgs : System.EventArgs
+        {
+            OSDispatcher.Current.InvokeOnMainDispatcher(() => handler(sender, args));
         }
 
         /// <summary>

--- a/Locutus/LtoFlash/View/MainWindow.Gtk.cs
+++ b/Locutus/LtoFlash/View/MainWindow.Gtk.cs
@@ -31,6 +31,9 @@ using INTV.Shared.ViewModel;
 
 namespace Locutus.View
 {
+    /// <summary>
+    /// GTK-specific implementation.
+    /// </summary>
     public partial class MainWindow : Gtk.Window
     {
         private Dictionary<string, Gdk.Pixbuf> _cachedImages = new Dictionary<string, Gdk.Pixbuf>();
@@ -85,7 +88,6 @@ namespace Locutus.View
                     viewModel.CollectionChanged += HandleRomListCollectionChanged;
                     viewModel.CurrentSelection.CollectionChanged += HandleRomListSelectionChanged;
                     HandleRomListCollectionChanged(viewModel, null);
-
                 }
                 else if (visual.UniqueId == MenuLayoutView.Id)
                 {
@@ -109,6 +111,11 @@ namespace Locutus.View
         }
 
         private void HandleLtoFlashPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            this.HandleEventOnMainThread(sender, e, HandleLtoFlashPropertyChangedCore);
+        }
+
+        private void HandleLtoFlashPropertyChangedCore(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             var viewModel = sender as LtoFlashViewModel;
             switch (e.PropertyName)
@@ -148,18 +155,20 @@ namespace Locutus.View
 
         private void HandleActiveDevicePropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            OSDispatcher.Current.InvokeOnMainDispatcher(() =>
-                {
-                    var device = sender as DeviceViewModel;
-                    switch (e.PropertyName)
-                    {
-                        case DeviceViewModel.DisplayNamePropertyName:
-                            UpdateActiveDeviceName(device);
-                            break;
-                        default:
-                            break;
-                    }
-                });
+            this.HandleEventOnMainThread(sender, e, HandleActiveDevicePropertyChangedCore);
+        }
+
+        private void HandleActiveDevicePropertyChangedCore(object sender, PropertyChangedEventArgs e)
+        {
+            var device = sender as DeviceViewModel;
+            switch (e.PropertyName)
+            {
+                case DeviceViewModel.DisplayNamePropertyName:
+                    UpdateActiveDeviceName(device);
+                    break;
+                default:
+                    break;
+            }
         }
 
         private void UpdateActiveDeviceName(DeviceViewModel device)
@@ -174,16 +183,26 @@ namespace Locutus.View
 
         private void HandleRomListSelectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
         {
+            this.HandleEventOnMainThread(sender, e, HandleRomListSelectionChangedCore);
+        }
+        
+        private void HandleRomListSelectionChangedCore(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
             var selection = sender as ObservableCollection<ProgramDescriptionViewModel>;
             _selectionCount = selection.Count;
             UpdateStatusBar();
 
-            var menuLayout =_layoutsNotebook.Children.OfType<MenuLayoutView>().FirstOrDefault();
+            var menuLayout = _layoutsNotebook.Children.OfType<MenuLayoutView>().FirstOrDefault();
             var ltoFlashViewModel = menuLayout.DataContext as LtoFlashViewModel;
             ltoFlashViewModel.CurrentSelection = selection;
         }
 
         private void HandleRomListCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            this.HandleEventOnMainThread(sender, e, HandleRomListCollectionChangedCore);
+        }
+        
+        private void HandleRomListCollectionChangedCore(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
         {
             var viewModel = sender as RomListViewModel;
             _itemCount = viewModel.Programs.Count;


### PR DESCRIPTION
Ensure various property changed handlers in visual types -- *especially* those from the model / view model side -- are all executed on the UI thread.

Some StyleCop cleanup came along for the ride.