### PR TITLE
Fix incorrect progress report value

### DIFF
--- a/INTV.Shared/View/ProgressIndicator.Gtk.cs
+++ b/INTV.Shared/View/ProgressIndicator.Gtk.cs
@@ -149,7 +149,7 @@ namespace INTV.Shared.View
                 case ProgressIndicatorViewModel.PercentFinishedPropertyName:
                     if (!viewModel.IsIndeterminate)
                     {
-                        _progressBar.Fraction = viewModel.PercentFinished;
+                        _progressBar.Fraction = viewModel.PercentFinished / 100;
                     }
                     break;
                 case ProgressIndicatorViewModel.IsVisiblePropertyName:


### PR DESCRIPTION
GTK progress bars report percent in 0-1 rather than 1-100.