### PR TITLE
Fixed a real forehead-slapper bug in the IgnoreRootFork function used…

### DIFF
--- a/INTV.LtoFlash/Model/FileSystemHelpers.cs
+++ b/INTV.LtoFlash/Model/FileSystemHelpers.cs
@@ -543,7 +543,7 @@ namespace INTV.LtoFlash.Model
             if (fork.GlobalForkNumber != GlobalForkTable.InvalidForkNumber)
             {
                 var rootFile = fork.FileSystem.Files[GlobalFileTable.RootDirectoryFileNumber];
-                ignore = (rootFile.Manual != null) && ((rootFile.Manual.GlobalForkNumber == fork.GlobalForkNumber) || (rootFile.JlpFlash.GlobalForkNumber == fork.GlobalForkNumber));
+                ignore = ((rootFile.Manual != null) && (rootFile.Manual.GlobalForkNumber == fork.GlobalForkNumber)) || ((rootFile.JlpFlash != null) && (rootFile.JlpFlash.GlobalForkNumber == fork.GlobalForkNumber));
             }
             return ignore;
         }


### PR DESCRIPTION
… during SimpleCompare. If you've never executed a 'Download and Play' on LTO Flash!, saved menu position on the cart, it's quite possible you'll hit this bug. And it's a hard crash. Embarrassing.