### PR TITLE
Add IStreamConnection InUse feature

### DIFF
--- a/INTV.Shared/Model/Device/NamedPipeConnection.cs
+++ b/INTV.Shared/Model/Device/NamedPipeConnection.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="NamedPipeConnection.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2016 All Rights Reserved
+// Copyright (c) 2014-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -113,6 +113,13 @@ namespace INTV.Shared.Model.Device
         public bool IsOpen
         {
             get { return IsConnected; }
+        }
+
+        /// <inheritdoc />
+        /// <remarks>Raw software model tester. Not bothering with an actual implementation.</remarks>
+        public bool IsInUse
+        {
+            get { return false; }
         }
 
         /// <inheritdoc />
@@ -264,6 +271,12 @@ namespace INTV.Shared.Model.Device
             {
                 PostOpenPort = (Action<IStreamConnection>)configData;
             }
+        }
+
+        /// <inheritdoc />
+        public IDisposable SetInUse(Action inUseEnded)
+        {
+            return null;
         }
 
         /// <inheritdoc />

--- a/INTV.Shared/Model/Device/SerialPortConnection.Mac.cs
+++ b/INTV.Shared/Model/Device/SerialPortConnection.Mac.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="SerialPortConnection.Mac.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2017 All Rights Reserved
+// Copyright (c) 2014-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -67,12 +67,6 @@ namespace INTV.Shared.Model.Device
                     break;
             }
             _availablePorts = ports.ToArray();
-        }
-
-        [System.Diagnostics.Conditional("ENABLE_DEBUG_OUTPUT")]
-        private static void DebugOutput(object message)
-        {
-            System.Diagnostics.Debug.WriteLine(message);
         }
 
         private void OpenPort()

--- a/INTV.Shared/Model/IStreamConnection.cs
+++ b/INTV.Shared/Model/IStreamConnection.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="IStreamConnection.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2016 All Rights Reserved
+// Copyright (c) 2014-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -18,6 +18,7 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -37,6 +38,11 @@ namespace INTV.Shared.Model
         /// Gets a value indicating whether the port is open for communication.
         /// </summary>
         bool IsOpen { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this instance is actively in use.
+        /// </summary>
+        bool IsInUse { get; }
 
         /// <summary>
         /// Gets the stream to use for read operations on the connection.
@@ -73,6 +79,13 @@ namespace INTV.Shared.Model
         /// </summary>
         /// <param name="configurationData">Configuration data for the connection. The expected format is in name-value pairs.</param>
         void Configure(IDictionary<string, object> configurationData);
+
+        /// <summary>
+        /// Sets the stream connection as being in use until the returned value is disposed.
+        /// </summary>
+        /// <param name="inUseEnded">Called when the port is no longer in use. May be <c>null</c>.</param>
+        /// <returns>An instance of an IDisposable that marks the connection as being in active use until disposed.</returns>
+        IDisposable SetInUse(Action inUseEnded);
 
         /// <summary>
         /// Estimates the amount of time it will take to transfer the given number of bytes, in milliseconds.


### PR DESCRIPTION
IStreamConnections now have the ability to provide a scoped 'In Use' object. This simply marks the port as 'busy' in a generic way. The new InUse property can then be used by client code to take actions or prevent actions depending on that state.

In the wider sense, some icky code in the INTV.LtoFlash assembly could probably be substantially cleaner - mainly the interaction between device commands and the ping/garbage collect timer.

Also, this will provide a way to hook into power management to prevent system sleep during long-running commands, if such a feature is necessary.