### PR TITLE
Add power management interface

### DIFF
--- a/INTV.LtoFlash/View/DeviceMonitor.WPF.cs
+++ b/INTV.LtoFlash/View/DeviceMonitor.WPF.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="DeviceMonitor.WPF.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2015 All Rights Reserved
+// Copyright (c) 2014-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -21,6 +21,7 @@
 ////#define ENABLE_DIAGNOSTIC_OUTPUT
 
 using System;
+using System.Collections.Generic;
 
 namespace INTV.LtoFlash.Model
 {
@@ -42,11 +43,15 @@ namespace INTV.LtoFlash.Model
             Title = "VINTage Device Monitor";
         }
 
+        private static Func<IEnumerable<Device>> GetDevices { get; set; }
+
         /// <summary>
         /// Starts the device monitor window.
         /// </summary>
-        public static void Start()
+        /// <param name="getDevices">The delegate to use to get the list of Locutus devices.</param>
+        public static void Start(Func<IEnumerable<Device>> getDevices)
         {
+            GetDevices = getDevices;
             System.Windows.Application.Current.Exit += HandleApplicationExit;
             Microsoft.Win32.SystemEvents.PowerModeChanged += HandlePowerModeChanged;
             Microsoft.Win32.SystemEvents.SessionEnding += HandleSessionEnding;

--- a/INTV.LtoFlash/ViewModel/LtoFlashViewModel.cs
+++ b/INTV.LtoFlash/ViewModel/LtoFlashViewModel.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="LtoFlashViewModel.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2017 All Rights Reserved
+// Copyright (c) 2014-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -151,7 +151,7 @@ namespace INTV.LtoFlash.ViewModel
 #endif // ENABLE_DRIVER_NAG
 
             Properties.Settings.Default.PropertyChanged += HandlePreferenceChanged;
-            DeviceMonitor.Start();
+            DeviceMonitor.Start(() => _devices.ModelCollection);
             if ((SingleInstanceApplication.Instance != null) && INTV.LtoFlash.Properties.Settings.Default.SearchForDevicesAtStartup)
             {
                 var checkForDevices = new CheckForDevicesTaskData(INTV.LtoFlash.Properties.Settings.Default.LastActiveDevicePort, this);

--- a/INTV.Shared/INTV.Shared.Gtk.csproj
+++ b/INTV.Shared/INTV.Shared.Gtk.csproj
@@ -310,6 +310,8 @@
     <Compile Include="..\VersionInfo.cs">
       <Link>Properties\VersionInfo.cs</Link>
     </Compile>
+    <Compile Include="Interop\DeviceManagement\ISystemPowerManagement.cs" />
+    <Compile Include="Interop\DeviceManagement\SystemWillSleepEventArgs.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/INTV.Shared/INTV.Shared.Mac.csproj
+++ b/INTV.Shared/INTV.Shared.Mac.csproj
@@ -380,6 +380,8 @@
     <Compile Include="..\VersionInfo.cs">
       <Link>Properties\VersionInfo.cs</Link>
     </Compile>
+    <Compile Include="Interop\DeviceManagement\ISystemPowerManagement.cs" />
+    <Compile Include="Interop\DeviceManagement\SystemWillSleepEventArgs.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Mono\MonoMac\v0.0\Mono.MonoMac.targets" />

--- a/INTV.Shared/INTV.Shared.Mac.csproj
+++ b/INTV.Shared/INTV.Shared.Mac.csproj
@@ -380,6 +380,8 @@
     <Compile Include="..\VersionInfo.cs">
       <Link>Properties\VersionInfo.cs</Link>
     </Compile>
+    <Compile Include="Interop\IOKit\IOConnect.cs" />
+    <Compile Include="Interop\IOKit\IOMessage.cs" />
     <Compile Include="Interop\DeviceManagement\ISystemPowerManagement.cs" />
     <Compile Include="Interop\DeviceManagement\SystemWillSleepEventArgs.cs" />
   </ItemGroup>

--- a/INTV.Shared/INTV.Shared.VSMac.csproj
+++ b/INTV.Shared/INTV.Shared.VSMac.csproj
@@ -380,6 +380,8 @@
     </Compile>
     <Compile Include="Interop\DeviceManagement\ISystemPowerManagement.cs" />
     <Compile Include="Interop\DeviceManagement\SystemWillSleepEventArgs.cs" />
+    <Compile Include="Interop\IOKit\IOConnect.cs" />
+    <Compile Include="Interop\IOKit\IOMessage.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\INTV.jzIntv\INTV.jzIntv.VSMac.csproj">

--- a/INTV.Shared/INTV.Shared.VSMac.csproj
+++ b/INTV.Shared/INTV.Shared.VSMac.csproj
@@ -378,6 +378,8 @@
     <Compile Include="..\VersionInfo.cs">
       <Link>Properties\VersionInfo.cs</Link>
     </Compile>
+    <Compile Include="Interop\DeviceManagement\ISystemPowerManagement.cs" />
+    <Compile Include="Interop\DeviceManagement\SystemWillSleepEventArgs.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\INTV.jzIntv\INTV.jzIntv.VSMac.csproj">

--- a/INTV.Shared/INTV.Shared.XamMac.csproj
+++ b/INTV.Shared/INTV.Shared.XamMac.csproj
@@ -378,6 +378,8 @@
     <Compile Include="..\VersionInfo.cs">
       <Link>Properties\VersionInfo.cs</Link>
     </Compile>
+    <Compile Include="Interop\DeviceManagement\ISystemPowerManagement.cs" />
+    <Compile Include="Interop\DeviceManagement\SystemWillSleepEventArgs.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\INTV.jzIntv\INTV.jzIntv.XamMac.csproj">

--- a/INTV.Shared/INTV.Shared.XamMac.csproj
+++ b/INTV.Shared/INTV.Shared.XamMac.csproj
@@ -380,6 +380,8 @@
     </Compile>
     <Compile Include="Interop\DeviceManagement\ISystemPowerManagement.cs" />
     <Compile Include="Interop\DeviceManagement\SystemWillSleepEventArgs.cs" />
+    <Compile Include="Interop\IOKit\IOConnect.cs" />
+    <Compile Include="Interop\IOKit\IOMessage.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\INTV.jzIntv\INTV.jzIntv.XamMac.csproj">

--- a/INTV.Shared/INTV.Shared.desktop.csproj
+++ b/INTV.Shared/INTV.Shared.desktop.csproj
@@ -147,6 +147,8 @@
     <Compile Include="Interop\DeviceManagement\DeviceChangeEvent.cs" />
     <Compile Include="Interop\DeviceManagement\DeviceType.cs" />
     <Compile Include="Interop\DeviceManagement\DeviceChange.cs" />
+    <Compile Include="Interop\DeviceManagement\ISystemPowerManagement.cs" />
+    <Compile Include="Interop\DeviceManagement\SystemWillSleepEventArgs.cs" />
     <Compile Include="Interop\SetupDi\DeviceInformation.cs" />
     <Compile Include="Interop\SetupDi\DeviceInformation.WPF.cs" />
     <Compile Include="Interop\SetupDi\NativeMethods.cs" />

--- a/INTV.Shared/INTV.Shared.xp.csproj
+++ b/INTV.Shared/INTV.Shared.xp.csproj
@@ -127,6 +127,8 @@
     <Compile Include="Interop\DeviceManagement\DeviceChangeEvent.cs" />
     <Compile Include="Interop\DeviceManagement\DeviceType.cs" />
     <Compile Include="Interop\DeviceManagement\DeviceChange.cs" />
+    <Compile Include="Interop\DeviceManagement\ISystemPowerManagement.cs" />
+    <Compile Include="Interop\DeviceManagement\SystemWillSleepEventArgs.cs" />
     <Compile Include="Interop\SetupDi\DeviceInformation.cs" />
     <Compile Include="Interop\SetupDi\DeviceInformation.xp.cs" />
     <Compile Include="Interop\SetupDi\NativeMethods.cs" />

--- a/INTV.Shared/Interop/DeviceManagement/DeviceChange.cs
+++ b/INTV.Shared/Interop/DeviceManagement/DeviceChange.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="DeviceChange.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2016 All Rights Reserved
+// Copyright (c) 2014-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -58,6 +58,8 @@ namespace INTV.Shared.Interop.DeviceManagement
 
         #endregion Configuration Data Parameter Names
 
+        #region Events
+
         /// <summary>
         /// This event is raised when a device has been added to the system.
         /// </summary>
@@ -67,6 +69,25 @@ namespace INTV.Shared.Interop.DeviceManagement
         /// This event is raised when a device has been removed from the system.,
         /// </summary>
         public static event EventHandler<DeviceChangeEventArgs> DeviceRemoved;
+
+        /// <summary>
+        /// This event is raised when the system will enter low power mode, potentially
+        /// cutting power to the serial ports or other devices. See <see cref="ISystemPowerManagement"/>
+        /// for more information.
+        /// </summary>
+        public static event EventHandler<SystemWillSleepEventArgs> SystemWillSleep;
+
+        /// <summary>
+        /// This event is raised when the system's power will be low or off. This cannot be canceled.
+        /// </summary>
+        public static event EventHandler<EventArgs> SystemWillPowerOff;
+
+        /// <summary>
+        /// This event is raised when the system resumes full power state after sleep.
+        /// </summary>
+        public static event EventHandler<EventArgs> SystemDidPowerOn;
+
+        #endregion // Events
 
         /// <summary>
         /// Report that a device has been added to or detected in the system.
@@ -174,6 +195,48 @@ namespace INTV.Shared.Interop.DeviceManagement
                 isFromSystem = (int)value == 0;
             }
             return isFromSystem;
+        }
+
+        /// <summary>
+        /// Raises the system will sleep event.
+        /// </summary>
+        /// <param name="sender">The originator of the event.</param>
+        /// <param name="args">See <see cref="SystemWillSleepEventArgs"/> for details..</param>
+        internal static void RaiseSystemWillSleepEvent(object sender, SystemWillSleepEventArgs args)
+        {
+            var systemWillSleep = SystemWillSleep;
+            if (systemWillSleep != null)
+            {
+                systemWillSleep(sender, args);
+            }
+        }
+
+        /// <summary>
+        /// Raises the system will power off event.
+        /// </summary>
+        /// <param name="sender">The originator of the event.</param>
+        /// <param name="args">Event arguments are not used.</param>
+        internal static void RaiseSystemWillPowerOffEvent(object sender, EventArgs args)
+        {
+            var systemWillPowerOff = SystemWillPowerOff;
+            if (systemWillPowerOff != null)
+            {
+                systemWillPowerOff(sender, args);
+            }
+        }
+
+        /// <summary>
+        /// Raises the system did power on event.
+        /// </summary>
+        /// <param name="sender">The originator of the event.</param>
+        /// <param name="args">Event arguments are not used.</param>
+        internal static void RaiseSystemDidPowerOnEvent(object sender, EventArgs args)
+        {
+            var systemDidPowerOn = SystemDidPowerOn;
+            if (systemDidPowerOn != null)
+            {
+                systemDidPowerOn(sender, args);
+            }
         }
 
         [System.Diagnostics.Conditional("REPORT_EMPTY_DEVICE_NAMES")]

--- a/INTV.Shared/Interop/DeviceManagement/ISystemPowerManagement.cs
+++ b/INTV.Shared/Interop/DeviceManagement/ISystemPowerManagement.cs
@@ -1,0 +1,50 @@
+﻿// <copyright file="ISystemPowerManagement.cs" company="INTV Funhouse">
+// Copyright (c) 2018 All Rights Reserved
+// <author>Steven A. Orth</author>
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this software. If not, see: http://www.gnu.org/licenses/.
+// or write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+// </copyright>
+
+using System;
+
+namespace INTV.Shared.Interop.DeviceManagement
+{
+    /// <summary>
+    /// This interface provides a way to respond to system power events, potentially
+    /// cancelling certain actions.
+    /// </summary>
+    /// <remarks>Note that no assumptions should be made by users of this interface regarding
+    /// the threads upon which these events will be raised.</remarks>
+    public interface ISystemPowerManagement
+    {
+        /// <summary>
+        /// Occurs when system will enter a lower-power mode -- e.g. sleep.
+        /// </summary>
+        /// <remarks>See <see cref="SystemWillSleepEventArgs"/> for more details regarding
+        /// how to process this event.</remarks>
+        event EventHandler<SystemWillSleepEventArgs> SystemWillSleep;
+
+        /// <summary>
+        /// Occurs when system will power off.
+        /// </summary>
+        event EventHandler<EventArgs> SystemWillPowerOff;
+
+        /// <summary>
+        /// Occurs when system did power on.
+        /// </summary>
+        event EventHandler<EventArgs> SystemDidPowerOn;
+    }
+}

--- a/INTV.Shared/Interop/DeviceManagement/SystemWillSleepEventArgs.cs
+++ b/INTV.Shared/Interop/DeviceManagement/SystemWillSleepEventArgs.cs
@@ -1,0 +1,53 @@
+﻿// <copyright file="SystemWillSleepEventArgs.cs" company="INTV Funhouse">
+// Copyright (c) 2018 All Rights Reserved
+// <author>Steven A. Orth</author>
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this software. If not, see: http://www.gnu.org/licenses/.
+// or write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+// </copyright>
+
+namespace INTV.Shared.Interop.DeviceManagement
+{
+    /// <summary>
+    /// Event data for the <see cref="ISystemPowerManagement.SystemWillSleep"/> event.
+    /// </summary>
+    public class SystemWillSleepEventArgs : System.EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the
+        /// <see cref="INTV.Shared.Interop.DeviceManagement.SystemWillSleepEventArgs"/> class.
+        /// </summary>
+        /// <param name="canCancel">If set to <c>true</c>, the recipient can cancel the entry to low-power (sleep) mode.
+        /// If set to <c>false</c>, any attempt to cancel will be ignored - or at best delay the entry to low-power
+        /// mode by some relatively brief amount of time.</param>
+        public SystemWillSleepEventArgs(bool canCancel)
+        {
+            CanCancel = canCancel;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether cancelling the entry to low-power mode is supported.
+        /// </summary>
+        /// <remarks>If this value is <c>false</c>, the value of <see cref="Cancel"/> will at most delay entering
+        /// lower power mode for a brief period of time.</remarks>
+        public bool CanCancel { get; private set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to cancel the system's entry to sleep (low power) mode.
+        /// </summary>
+        /// <remarks>This value may be ignored, depending on the value of <see cref="CanCancel"/>.</remarks>
+        public bool Cancel { get; set; }
+    }
+}

--- a/INTV.Shared/Interop/IOKit/IOConnect.cs
+++ b/INTV.Shared/Interop/IOKit/IOConnect.cs
@@ -1,0 +1,180 @@
+﻿// <copyright file="IOConnect.cs" company="INTV Funhouse">
+// Copyright (c) 2018 All Rights Reserved
+// <author>Steven A. Orth</author>
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this software. If not, see: http://www.gnu.org/licenses/.
+// or write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+// </copyright>
+
+#define ENABLE_DEBUG_OUTPUT
+
+#if __UNIFIED__
+using Foundation;
+using nint = System.nint;
+#else
+using MonoMac.Foundation;
+using nint = System.Int32;
+#endif // __UNIFIED__
+
+namespace INTV.Shared.Interop.IOKit
+{
+    /// <summary>
+    /// IO service interest callback.
+    /// </summary>
+    /// <param name="refcon">Custom (native) data passed to the delegate when initially registered and then when invoked.</param>
+    /// <param name="service">The native object pointer of the service whose state has changed.</param>
+    /// <param name="messageType">The type of the message - see <see cref="IOMessage"/> for details.</param>
+    /// <param name="messageArgument">Data specific to the <paramref name="messageType"/> argument.</param>
+    public delegate void IOServiceInterestCallback(System.IntPtr refcon, System.IntPtr service, uint messageType, System.IntPtr messageArgument);
+
+    /// <summary>
+    /// A partial wrapper for the parts of io_connect_t that is needed.
+    /// </summary>
+    public class IOConnect : IOKitObject
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="INTV.Shared.Interop.IOKit.IOConnect"/> class.
+        /// </summary>
+        public IOConnect()
+            : this(System.IntPtr.Zero)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="INTV.Shared.Interop.IOKit.IOConnect"/> class.
+        /// </summary>
+        /// <param name="nativeObject">Native object.</param>
+        internal IOConnect(System.IntPtr nativeObject)
+            : base(nativeObject)
+        {
+        }
+
+        /// <summary>
+        /// Gets the notification port returned when the connection was created.
+        /// </summary>
+        public IONotificationPort NotificationPort { get; private set; }
+
+        private IOKitObject Notifier { get; set; }
+
+        /// <summary>
+        /// Creates the system power monitor connection.
+        /// </summary>
+        /// <param name="systemPowerDelegate">System power delegate.</param>
+        /// <param name="callbackData">Callback data.</param>
+        /// <returns>The system power monitor connection.</returns>
+        /// <remarks>The caller must add the <see cref="IOConnect.NotificationPort"/> to a CFRunLoop in order for
+        /// <paramref name="systemPowerDelegate"/> to be called. When the consumer of the returned IO connection
+        /// is finished, first, remove the NotificationPort from the CFRunLoop, then call the Dispose() method.</remarks>
+        public static IOConnect CreateSystemPowerMonitorConnection(IOServiceInterestCallback systemPowerDelegate, NSObject callbackData)
+        {
+            return IORegisterForSystemPower(systemPowerDelegate, callbackData);
+        }
+
+        private static IOConnect IORegisterForSystemPower(IOServiceInterestCallback systemPowerDelegate, NSObject refcon)
+        {
+            var ioNotificationPort = System.IntPtr.Zero;
+            var notifierHandle = System.IntPtr.Zero;
+            var callback = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(systemPowerDelegate);
+            var nativeIOConnect = NativeMethods.IORegisterForSystemPower(refcon.Handle, out ioNotificationPort, callback, out notifierHandle);
+
+            var ioConnect = IOKitObject.CreateIOKitObject<IOConnect>(nativeIOConnect);
+            ioConnect.NotificationPort = new IONotificationPort(ioNotificationPort);
+            ioConnect.Notifier = IOKitObject.CreateIOKitObject<IOKitObject>(notifierHandle, n => IODeregisterForSystemPower(n));
+            return ioConnect;
+        }
+
+        /// <summary>
+        /// The caller acknowledges notification of a power state change on a device it has registered
+        /// for notifications for via IORegisterForSystemPower.
+        /// </summary>
+        /// <param name="notificationId">Notification identifier.</param>
+        /// <returns>The result of the funcion call - 0 indicates success, otherwise an error code.</returns>
+        public int AllowPowerChange(nint notificationId)
+        {
+            return NativeMethods.IOAllowPowerChange(Handle, notificationId);
+        }
+
+        /// <summary>
+        /// The caller wishes to cancel a change in poewr state. The request may or may not be
+        /// honored, depending on system state.
+        /// </summary>
+        /// <param name="notificationId">Notification identifier.</param>
+        /// <returns>The result of the funcion call - 0 indicates success, otherwise an error code.</returns>
+        public int CancelPowerChange(nint notificationId)
+        {
+            return NativeMethods.IOCancelPowerChange(Handle, notificationId);
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (!Disposed)
+            {
+                DebugOutput("**** IOConnect.Dispose(bool) for " + GetType() + " marking disposed, RetainCount: " + RetainCount);
+                Disposed = true;
+
+                // The order of disposal here is based on the example at:
+                // https://developer.apple.com/library/content/qa/qa1340/_index.html
+                // Alternative ordering has not been tested.
+                // Also, this code assumes that the NotificationPort has been removed from any run loops.
+
+                // First, de-register the notifier.
+                if (Notifier != null)
+                {
+                    Notifier.Dispose();
+                }
+                Notifier = null;
+
+                // Now, close this IO connection.
+                var handle = Handle;
+                if (handle != System.IntPtr.Zero)
+                {
+                    IOService.Close(this);
+                    ClearHandle();
+                }
+
+                // Finally, destroy the notification port itself.
+                if (NotificationPort != null)
+                {
+                    NotificationPort.Dispose();
+                }
+                NotificationPort = null;
+
+                DebugOutput("**** IOConnect.Dispose(bool) for " + GetType() + " called IOServerClose, RetainCount: " + NativeMethods.IOObjectGetUserRetainCount(handle));
+            }
+        }
+
+        /// <summary>
+        /// Deregisters a notifier created via <see cref="IORegisterForSystemPower"/>.
+        /// </summary>
+        /// <param name="notifier">The notifier to de-register.</param>
+        /// <returns>The result of the deregister operation.</returns>
+        private static int IODeregisterForSystemPower(IOKitObject notifier)
+        {
+            var handle = notifier.Handle;
+            var result = NativeMethods.IODeregisterForSystemPower(ref handle);
+            DebugOutput("IOService: IODeregisterForSystemPower() returned: " + result);
+
+            // Should we throw if an error occurs? Called from Dispose() -- would that be a bad idea?
+            return result;
+        }
+
+        [System.Diagnostics.Conditional("ENABLE_DEBUG_OUTPUT")]
+        private static void DebugOutput(object message)
+        {
+            System.Diagnostics.Debug.WriteLine(message);
+        }
+    }
+}

--- a/INTV.Shared/Interop/IOKit/IOMessage.cs
+++ b/INTV.Shared/Interop/IOKit/IOMessage.cs
@@ -1,0 +1,184 @@
+﻿// <copyright file="IOMessage.cs" company="INTV Funhouse">
+// Copyright (c) 2018 All Rights Reserved
+// <author>Steven A. Orth</author>
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this software. If not, see: http://www.gnu.org/licenses/.
+// or write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+// </copyright>
+
+using System;
+
+namespace INTV.Shared.Interop.IOKit
+{
+    /// <summary>
+    /// Values from the IOMessage.h, IOReturn.h and related headers in IOKit.
+    /// </summary>
+    /// <remarks>Unused and deprecated values are not included.</remarks>
+    public enum IOMessage : uint
+    {
+        #region General Interest Messages
+
+        /// <summary>
+        /// The IO service is terminated.
+        /// </summary>
+        KIOMessageServiceIsTerminated = IOMessageHelpers.CommonMessage | 0x010,
+
+        /// <summary>
+        /// The IO service is suspended.
+        /// </summary>
+        KIOMessageServiceIsSuspended = IOMessageHelpers.CommonMessage | 0x020,
+
+        /// <summary>
+        /// The IO message service is resumed.
+        /// </summary>
+        KIOMessageServiceIsResumed = IOMessageHelpers.CommonMessage | 0x030,
+
+        /// <summary>
+        /// The IO service is requesting close.
+        /// </summary>
+        KIOMessageServiceIsRequestingClose = IOMessageHelpers.CommonMessage | 0x100,
+
+        /// <summary>
+        /// The IO service is attempting open.
+        /// </summary>
+        KIOMessageServiceIsAttemptingOpen = IOMessageHelpers.CommonMessage | 0x101,
+
+        /// <summary>
+        /// The IO service was closed.
+        /// </summary>
+        KIOMessageServiceWasClosed = IOMessageHelpers.CommonMessage | 0x110,
+
+        /// <summary>
+        /// The IO service busy state changed.
+        /// </summary>
+        KIOMessageServiceBusyStateChange = IOMessageHelpers.CommonMessage | 0x120,
+
+        /// <summary>
+        /// The IO console security changed.
+        /// </summary>
+        KIOMessageConsoleSecurityChange = IOMessageHelpers.CommonMessage | 0x128,
+
+        /// <summary>
+        /// An IO service property changed.
+        /// </summary>
+        KIOMessageServicePropertyChange = IOMessageHelpers.CommonMessage | 0x130,
+
+        /// <summary>
+        /// The IO copy client ID message.
+        /// </summary>
+        KIOMessageCopyClientID = IOMessageHelpers.CommonMessage | 0x330,
+
+        /// <summary>
+        /// The system capability changed.
+        /// </summary>
+        KIOMessageSystemCapabilityChange = IOMessageHelpers.CommonMessage | 0x340,
+
+        /// <summary>
+        /// The IO device signaled wakeup.
+        /// </summary>
+        KIOMessageDeviceSignaledWakeup = IOMessageHelpers.CommonMessage | 0x350,
+
+        /// <summary>
+        /// The device will move to a lower power state.
+        /// Sent to notification clients of kind kIOAppPowerStateInterest and kIOGeneralInterest.
+        /// </summary>
+        KIOMessageDeviceWillPowerOff = IOMessageHelpers.CommonMessage | 0x210,
+
+        /// <summary>
+        /// The device has must moved to a higher power state.
+        /// Sent to notification clients of kind kIOAppPowerStateInterest and kIOGeneralInterest.
+        /// </summary>
+        KIOMessageDeviceHasPoweredOn = IOMessageHelpers.CommonMessage | 0x230,
+
+        #endregion General Interest Messages
+
+        #region In-Kernel System Shutdown and Restart Notifications
+
+        /// <summary>
+        /// Indicates an imminent system shutdown. Recipients have a limited 
+        /// amount of time to respond, otherwise the system will timeout and
+        /// shutdown even without a response. Never delivered to user space notification clients.
+        /// </summary>
+        KIOMessageSystemWillPowerOff = IOMessageHelpers.CommonMessage | 0x250,
+
+        /// <summary>
+        /// Indicates an imminent system restart. Recipients have a limited
+        /// amount of time to respond, otherwise the system will timeout and
+        /// restart even without a response. 
+        /// Never delivered to user space notification clients.
+        /// </summary>
+        KIOMessageSystemWillRestart = IOMessageHelpers.CommonMessage | 0x310,
+
+        /// <summary>
+        /// Indicates an imminent system shutdown, paging device now unavailable.
+        /// Recipients have a limited amount of time to respond, otherwise the
+        /// system will timeout and shutdown even without a response.
+        /// Never delivered to user space notification clients.
+        /// </summary>
+        KIOMessageSystemPagingOff = IOMessageHelpers.CommonMessage | 0x255,
+
+        #endregion // In-Kernel System Shutdown and Restart Notifications
+
+        #region System Sleep and Wake Notifications
+
+        /// <summary>
+        /// Announces/Requests permission to proceed to system sleep.
+        /// Delivered to user clients of IORegisterForSystemPower.
+        /// </summary>
+        KIOMessageCanSystemSleep = IOMessageHelpers.CommonMessage | 0x270,
+
+        /// <summary>
+        /// Announces that the system has retracted a previous attempt to sleep,
+        /// it follows kIOMessageCanSystemSleep. Delivered to user clients of IORegisterForSystemPower.
+        /// </summary>
+        KIOMessageSystemWillNotSleep = IOMessageHelpers.CommonMessage | 0x290,
+
+        /// <summary>
+        /// Announces that sleep is beginning.
+        /// Delivered to user clients of IORegisterForSystemPower.
+        /// </summary>
+        KIOMessageSystemWillSleep = IOMessageHelpers.CommonMessage | 0x280,
+
+        /// <summary>
+        /// TAnnounces that the system is beginning to power the device tree, most 
+        /// devices are unavailable at this point. Delivered to user clients of IORegisterForSystemPower.
+        /// </summary>
+        KIOMessageSystemWillPowerOn = IOMessageHelpers.CommonMessage | 0x320,
+
+        /// <summary>
+        /// Announces that the system and its devices have woken up.
+        /// Delivered to user clients of IORegisterForSystemPower.
+        /// </summary>
+        KIOMessageSystemHasPoweredOn = IOMessageHelpers.CommonMessage | 0x300,
+
+        #endregion // System Sleep and Wake Notifications
+    }
+
+    /// <summary>
+    /// Some helper values for use with defining IOMessage. Note that the general macros
+    /// were not used. Instead, the values specifically needed for IOKit power monitoring are
+    /// presented,
+    /// </summary>
+    internal static class IOMessageHelpers
+    {
+        private const uint SysIOKit = (0x38u & 0x3f) << 26;
+        private const uint SubIOKitCommon = 0;
+
+        /// <summary>
+        /// The base value used to OR with a specific message value to produce an IOKit IOMessage value.
+        /// </summary>
+        public const uint CommonMessage = SysIOKit | SubIOKitCommon;
+    }
+}

--- a/INTV.Shared/Interop/IOKit/IONotificationPort.cs
+++ b/INTV.Shared/Interop/IOKit/IONotificationPort.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="IONotificationPort.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2017 All Rights Reserved
+// Copyright (c) 2014-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -42,6 +42,15 @@ namespace INTV.Shared.Interop.IOKit
         public IONotificationPort()
         {
             Handle = NativeMethods.IONotificationPortCreate(IntPtr.Zero);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="INTV.Shared.Interop.IOKit.IONotificationPort"/> class.
+        /// </summary>
+        /// <param name="nativeObject">The native IOKit object pointer.</param>
+        public IONotificationPort(IntPtr nativeObject)
+        {
+            Handle = nativeObject;
         }
 
         #region INativeObject implementation

--- a/INTV.Shared/Interop/IOKit/IOService.cs
+++ b/INTV.Shared/Interop/IOKit/IOService.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="IOService.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2017 All Rights Reserved
+// Copyright (c) 2014-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -19,17 +19,20 @@
 // </copyright>
 
 #define USE_IOKIT_NOTIFICATIONS
-////#define ENABLE_DEBUG_OUTPUT
+#define ENABLE_DEBUG_OUTPUT
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
 using INTV.Shared.Interop.DeviceManagement;
 #if __UNIFIED__
+using AppKit;
 using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 #else
+using MonoMac.AppKit;
 using MonoMac.CoreFoundation;
 using MonoMac.Foundation;
 using MonoMac.ObjCRuntime;
@@ -37,15 +40,41 @@ using MonoMac.ObjCRuntime;
 
 #if __UNIFIED__
 using CFRunLoopString = Foundation.NSString;
+using nint = System.nint;
 #else
 using CFRunLoopString = System.String;
+using nint = System.Int32;
 #endif // __UNIFIED__
 
 namespace INTV.Shared.Interop.IOKit
 {
     /// <summary>
-    /// Class to act as a C# version of the IOKit IOService type.
+    /// These flags describe which IOServices have some level of support.
     /// </summary>
+    [Flags]
+    public enum IOServices
+    {
+        /// <summary>No services.</summary>
+        None = 0,
+
+        /// <summary>Report serial port arrival / departure.</summary>
+        SerialPort = 1 << 0,
+
+        /// <summary>Report system power events (enter/exit sleep / low power).</summary>
+        SystemPower = 1 << 1,
+
+        /// <summary>All available services.</summary>
+        All = SerialPort | SystemPower
+    }
+
+    /// <summary>
+    /// This class acts partially as a C# version of the IOKit IOService type.
+    /// </summary>
+    /// <remarks>Maybe this should be reworked and split up, because this most definitely does NOT
+    /// act as a partial exposure of the IOService API. At this point, it does two very non-generic
+    /// things:
+    /// 1. Monitors for the arrival and departure of serial ports in the system
+    /// 2. Provides access to the power domain IOService</remarks>
     public class IOService : IORegistryEntry
     {
         #region IOService notification types
@@ -58,7 +87,7 @@ namespace INTV.Shared.Interop.IOKit
 
         #endregion // IOService notification types
 
-        private delegate void IONotificationPortCallback(System.IntPtr refcon, System.IntPtr iterator);
+        private delegate void IONotificationPortCallback(IntPtr refcon, IntPtr iterator);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="INTV.Shared.Interop.IOKit.IOService"/> class.
@@ -69,6 +98,8 @@ namespace INTV.Shared.Interop.IOKit
 
         private ISerialPortNotifier PortNotifier { get; set; }
 
+        private IOServices Services { get; set; }
+
         /// <summary>
         /// Gets the IOServices matching the given name.
         /// </summary>
@@ -78,7 +109,7 @@ namespace INTV.Shared.Interop.IOKit
         {
             NSMutableDictionary dictionary = null;
             var dictionaryPointer = NativeMethods.IOServiceMatching(name);
-            if (dictionaryPointer != System.IntPtr.Zero)
+            if (dictionaryPointer != IntPtr.Zero)
             {
                 dictionary = Runtime.GetNSObject(dictionaryPointer) as NSMutableDictionary;
             }
@@ -86,23 +117,43 @@ namespace INTV.Shared.Interop.IOKit
         }
 
         /// <summary>
-        /// Starts the serial port monitor.
+        /// Close a connection to an IOService and destroy the connect handle. This should be called
+        /// via a custom dispose action installed when the IOKitObject was created, rather than directly.
         /// </summary>
-        public void StartSerialPortMonitor()
+        /// <param name="connect">The IOKit connection to close.</param>
+        /// <returns>The result of the function call.</returns>
+        public static int Close(IOKitObject connect)
         {
-            DebugOutput("IOService: StartSerialPortMonitor");
-            PortNotifier = CreatePortNotifier();
-            PortNotifier.Start();
+            var result = NativeMethods.IOServiceClose(connect.Handle);
+            DebugOutput("IOService: Close() returned: " + result);
+
+            // How to report if an error occurs? This is typically called from Dispose() -- throwing is a bad idea.
+            return result;
         }
 
         /// <summary>
-        /// Stops the serial port monitor.
+        /// Start the specified services.
         /// </summary>
-        public void StopSerialPortMonitor()
+        /// <param name="services">Services to start.</param>
+        /// <remarks>The serial port and power services are joined at the hip and rather inseparable at this point.</remarks>
+        public void StartServices(IOServices services)
         {
-            DebugOutput("IOService: StopSerialPortMonitor");
-            PortNotifier.Stop();
-            PortNotifier = null;
+            Services = services;
+            if (services.HasFlag(IOServices.SerialPort) || services.HasFlag(IOServices.SystemPower))
+            {
+                StartSerialPortMonitor();
+            }
+        }
+
+        /// <summary>
+        /// Stops all running IOServices.
+        /// </summary>
+        public void StopAllServices()
+        {
+            if (Services.HasFlag(IOServices.SerialPort) || Services.HasFlag(IOServices.SystemPower))
+            {
+                StopSerialPortMonitor();
+            }
         }
 
         private static ISerialPortNotifier CreatePortNotifier()
@@ -141,6 +192,55 @@ namespace INTV.Shared.Interop.IOKit
             System.Diagnostics.Debug.WriteLine(message);
         }
 
+        /// <summary>
+        /// Starts the serial port monitor.
+        /// </summary>
+        private void StartSerialPortMonitor()
+        {
+            DebugOutput("IOService: StartSerialPortMonitor");
+            PortNotifier = CreatePortNotifier();
+            var systemPowerManagement = PortNotifier as ISystemPowerManagement;
+            if (systemPowerManagement != null)
+            {
+                systemPowerManagement.SystemWillSleep += HandleSystemWillSleep;
+                systemPowerManagement.SystemWillPowerOff += HandleSystemWillPowerOff;
+                systemPowerManagement.SystemDidPowerOn += HandleSystemDidPowerOn;
+            }
+            PortNotifier.Start();
+        }
+
+        /// <summary>
+        /// Stops the serial port monitor.
+        /// </summary>
+        private void StopSerialPortMonitor()
+        {
+            DebugOutput("IOService: StopSerialPortMonitor");
+            var systemPowerManagement = PortNotifier as ISystemPowerManagement;
+            if (systemPowerManagement != null)
+            {
+                systemPowerManagement.SystemDidPowerOn -= HandleSystemDidPowerOn;
+                systemPowerManagement.SystemWillPowerOff -= HandleSystemWillPowerOff;
+                systemPowerManagement.SystemWillSleep -= HandleSystemWillSleep;
+            }
+            PortNotifier.Stop();
+            PortNotifier = null;
+        }
+
+        private void HandleSystemWillSleep(object sender, SystemWillSleepEventArgs args)
+        {
+            DeviceChange.RaiseSystemWillSleepEvent(sender, args);
+        }
+
+        private void HandleSystemWillPowerOff(object sender, EventArgs args)
+        {
+            DeviceChange.RaiseSystemWillPowerOffEvent(sender, args);
+        }
+
+        private void HandleSystemDidPowerOn(object sender, EventArgs args)
+        {
+            DeviceChange.RaiseSystemDidPowerOnEvent(sender, args);
+        }
+
         private class PortNotifierThread : NSThread
         {
             public PortNotifierThread(SerialPortNotifier portNotifier)
@@ -177,41 +277,208 @@ namespace INTV.Shared.Interop.IOKit
             }
         }
 
+        /// <summary>
+        /// Provides access to system power state events implemented using NSWorkspace observers.
+        /// The observers must run in the UI thread. This acts as a proxy implementation of the
+        /// ISystemPowerManagement interface for non-IOKit serial port notification services.
+        /// </summary>
+        private class NSWorkspaceSystemPowerObserver
+        {
+            /// <summary>
+            /// Initializes a new instance of the
+            /// <see cref="INTV.Shared.Interop.IOKit.IOService+NSWorkspaceSystemPowerObserver"/> class.
+            /// </summary>
+            /// <param name="willSleepHander">The handler to call when the system will enter sleep mode.</param>
+            /// <param name="willPowerOffHandler">The handler to call when the system Will power off.</param>
+            /// <param name="didPowerOnHandler">The handler to call when the system has powered on.</param>
+            public NSWorkspaceSystemPowerObserver(Action<SystemWillSleepEventArgs> willSleepHander, Action willPowerOffHandler, Action didPowerOnHandler)
+            {
+                WillSleepHandler = willSleepHander;
+                WillPowerOffHandler = willPowerOffHandler;
+                DidPowerOnHandler = didPowerOnHandler;
+            }
+
+            private NSObject WillSleepObserver { get; set; }
+            private NSObject WillPowerOffObserver { get; set; }
+            private NSObject DidWakeObserver { get; set; }
+            private Action<SystemWillSleepEventArgs> WillSleepHandler { get; set; }
+            private Action WillPowerOffHandler { get; set; }
+            private Action DidPowerOnHandler { get; set; }
+
+            /// <summary>
+            /// Start observers for NSWorkspace system power events.
+            /// </summary>
+            public void Start()
+            {
+                WillPowerOffObserver = NSWorkspace.Notifications.ObserveWillPowerOff(OnWillPowerOff);
+                WillSleepObserver = NSWorkspace.Notifications.ObserveWillSleep(OnWillSleep);
+                DidWakeObserver = NSWorkspace.Notifications.ObserveDidWake(OnDidWake);
+            }
+
+            // Stop observers for NSWorkspace system power events.
+            public void Stop()
+            {
+                NSWorkspace.SharedWorkspace.NotificationCenter.RemoveObserver(DidWakeObserver);
+                NSWorkspace.SharedWorkspace.NotificationCenter.RemoveObserver(WillSleepObserver);
+                NSWorkspace.SharedWorkspace.NotificationCenter.RemoveObserver(WillPowerOffObserver);
+                DidWakeObserver = null;
+                WillSleepObserver = null;
+                WillPowerOffObserver = null;
+            }
+
+            private void OnWillPowerOff(object sender, NSNotificationEventArgs e)
+            {
+                DebugOutput("NSWorkspaceSystemPowerObserver.OnWillPowerOff: name: " + e.Notification.Name);
+                WillPowerOffHandler();
+            }
+
+            private void OnWillSleep(object sender, NSNotificationEventArgs e)
+            {
+                DebugOutput("NSWorkspaceSystemPowerObserver.OnWillSleep: name: " + e.Notification.Name);
+                WillSleepHandler(new SystemWillSleepEventArgs(false));
+            }
+
+            private void OnDidWake(object sender, NSNotificationEventArgs e)
+            {
+                DebugOutput("NSWorkspaceSystemPowerObserver.OnDidWake: name: " + e.Notification.Name);
+                DidPowerOnHandler();
+            }
+        }
+
+        /// <summary>
+        /// A simple interface for starting and stopping serial port arrival / departure notifications.
+        /// </summary>
         private interface ISerialPortNotifier
         {
+            /// <summary>
+            /// Start the serial port notification service.
+            /// </summary>
             void Start();
+
+            /// <summary>
+            /// Stop the serial port notification service.
+            /// </summary>
             void Stop();
         }
 
-        private abstract class SerialPortNotifier : NSObject, ISerialPortNotifier
+        /// <summary>
+        /// Provides common implementation for different incarnations of serial port notifications. If a
+        /// particular mechanism for detecing port arrival / departure proves unreliable, it's possible to
+        /// choose an alternative implementation.
+        /// </summary>
+        private abstract class SerialPortNotifier : NSObject, ISerialPortNotifier, ISystemPowerManagement
         {
-            protected PortNotifierThread NotifierThread { get; private set; }
-
+            /// <summary>
+            /// Initializes a new instance of the <see cref="INTV.Shared.Interop.IOKit.IOService+SerialPortNotifier"/> class.
+            /// </summary>
             protected SerialPortNotifier()
             {
                 NotifierThread = new PortNotifierThread(this);
             }
 
-            public void Start()
+            /// <summary>
+            /// Gets the notifier thread upon which the notification work runs.
+            /// </summary>
+            protected PortNotifierThread NotifierThread { get; private set; }
+
+            /// <inheritdoc/>
+            public event EventHandler<SystemWillSleepEventArgs> SystemWillSleep;
+
+            /// <inheritdoc/>
+            public event EventHandler<EventArgs> SystemWillPowerOff;
+
+            /// <inheritdoc/>
+            public event EventHandler<EventArgs> SystemDidPowerOn;
+
+            /// <inheritdoc/>
+            public virtual void Start()
             {
                 NotifierThread.Start();
             }
 
-            public void Stop()
+            /// <inheritdoc/>
+            public virtual void Stop()
             {
                 NotifierThread.Stop();
             }
 
+            /// <summary>
+            /// Starts the implementation's worker thread.
+            /// </summary>
             internal abstract void StartInThread();
 
+            /// <summary>
+            /// Stops the implementation's worker thread.
+            /// </summary>
             internal abstract void StopInThread();
+
+            /// <summary>
+            /// Raises the system will sleep event.
+            /// </summary>
+            /// <param name="args">The arguments to send for the event.</param>
+            protected virtual void OnSystemWillSleep(SystemWillSleepEventArgs args)
+            {
+                DebugOutput("IOServer.SerialPortNotifier raising: OnSystemWillSleep: CanCancel: " + args.CanCancel);
+                var systemWillSleep = SystemWillSleep;
+                if (systemWillSleep != null)
+                {
+                    systemWillSleep(this, args);
+                }
+            }
+
+            /// <summary>
+            /// Raises the system will power off event.
+            /// </summary>
+            protected virtual void OnSystemWillPowerOff()
+            {
+                DebugOutput("IOServer.SerialPortNotifier raising: OnSystemWillPowerOff");
+                var systemWillPowerOff = SystemWillPowerOff;
+                if (systemWillPowerOff != null)
+                {
+                    systemWillPowerOff(this, EventArgs.Empty);
+                }
+            }
+
+            /// <summary>
+            /// Raises the system did power on event.
+            /// </summary>
+            protected virtual void OnSystemDidPowerOn()
+            {
+                DebugOutput("IOServer.SerialPortNotifier raising: OnSystemDidPowerOn");
+                var systemDidPowerOn = SystemDidPowerOn;
+                if (systemDidPowerOn != null)
+                {
+                    systemDidPowerOn(this, EventArgs.Empty);
+                }
+            }
         }
 
+        /// <summary>
+        /// Implements serial port arrival and departure notifications using a file system watcher.
+        /// </summary>
         private class FileSystemNotifcationPort : SerialPortNotifier
         {
             private System.IO.FileSystemWatcher DevWatcher { get; set; }
             private RunLoopSource CFRLSource { get; set; }
+            private NSWorkspaceSystemPowerObserver SystemPowerObserver { get; set; }
 
+            /// <inheritdoc/>
+            public override void Start()
+            {
+                base.Start();
+                SystemPowerObserver = new NSWorkspaceSystemPowerObserver(OnSystemWillSleep, OnSystemWillPowerOff, OnSystemDidPowerOn);
+                SystemPowerObserver.Start();
+            }
+
+            /// <inheritdoc/>
+            public override void Stop()
+            {
+                SystemPowerObserver.Stop();
+                SystemPowerObserver = null;
+                base.Stop();
+            }
+
+            /// <inheritdoc/>
             internal override void StartInThread()
             {
                 // We use our own custom (no-op) CFRunLoopSource so the NSThread we're started in won't immediately return.
@@ -235,6 +502,7 @@ namespace INTV.Shared.Interop.IOKit
                 DevWatcher.EnableRaisingEvents = true;
             }
 
+            /// <inheritdoc/>
             internal override void StopInThread()
             {
                 DebugOutput("IOService.FileSystemNotifcationPort: StopInThread");
@@ -282,17 +550,41 @@ namespace INTV.Shared.Interop.IOKit
             }
         }
 
+        /// <summary>
+        /// Implements serial port arrival and departure notifications using the IORegistry.
+        /// </summary>
         private class IORegNotification : SerialPortNotifier
         {
+            private NSWorkspaceSystemPowerObserver SystemPowerObserver { get; set; }
+
             #region SerialPortNotifier
 
+            /// <inheritdoc/>
+            public override void Start()
+            {
+                base.Start();
+                SystemPowerObserver = new NSWorkspaceSystemPowerObserver(OnSystemWillSleep, OnSystemWillPowerOff, OnSystemDidPowerOn);
+                SystemPowerObserver.Start();
+            }
+
+            /// <inheritdoc/>
+            public override void Stop()
+            {
+                SystemPowerObserver.Stop();
+                SystemPowerObserver = null;
+                base.Stop();
+            }
+
+            /// <inheritdoc/>
             internal override void StartInThread()
             {
-                throw new System.NotImplementedException("IORegNotification: StartInThread not implemented.");
+                throw new NotImplementedException("IORegNotification: StartInThread not implemented.");
             }
+
+            /// <inheritdoc/>
             internal override void StopInThread()
             {
-                throw new System.NotImplementedException("IORegNotification: StopInThread not implemented.");
+                throw new NotImplementedException("IORegNotification: StopInThread not implemented.");
             }
 
             #endregion // SerialPortNotifier
@@ -303,11 +595,18 @@ namespace INTV.Shared.Interop.IOKit
             private IONotificationPort NotificationPort { get; set; }
             private IOIterator PublishNotificationIterator { get; set; }
             private IOIterator TerminateNotificationIterator { get; set; }
+            private IOConnect IOConnectionPort { get; set; }
 
+            /// <inheritdoc/>
             internal override void StartInThread()
             {
                 NotificationPort = new IONotificationPort();
                 Interop.NativeMethods.CFRunLoopAddSource(CFRunLoop.Current, NotificationPort.RunLoopSource, (NSString)CFRunLoop.ModeDefault);
+
+                var systemPowerDelegate = new IOServiceInterestCallback(SystemPowerInterestCallback);
+                IOConnectionPort = IOConnect.CreateSystemPowerMonitorConnection(systemPowerDelegate, this);
+                Interop.NativeMethods.CFRunLoopAddSource(CFRunLoop.Current, IOConnectionPort.NotificationPort.RunLoopSource, (NSString)CFRunLoop.ModeCommon);
+
                 var servicesDictionary = IOMachPort.GetRS232SerialMatchDictionary();
 #if __UNIFIED__
                 servicesDictionary.DangerousRetain(); // retain an extra time because we're using it twice
@@ -317,9 +616,9 @@ namespace INTV.Shared.Interop.IOKit
                 var publishDelegate = new IONotificationPortCallback(FirstMatchNotification);
                 var callback = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(publishDelegate);
 
-                System.IntPtr iterator;
-                var result = NativeMethods.IOServiceAddMatchingNotification(NotificationPort.Handle, KIOFirstMatchNotification, servicesDictionary.Handle, callback, System.IntPtr.Zero, out iterator);
-                System.Diagnostics.Debug.Assert(result == NativeMethods.Success, "Failed to add notification.");
+                IntPtr iterator;
+                var result = NativeMethods.IOServiceAddMatchingNotification(NotificationPort.Handle, KIOFirstMatchNotification, servicesDictionary.Handle, callback, IntPtr.Zero, out iterator);
+                System.Diagnostics.Debug.Assert(result == NativeMethods.Success, "IOService.IOKitNotificationPort: Failed to add notification.");
 
                 if (result == NativeMethods.Success)
                 {
@@ -327,7 +626,7 @@ namespace INTV.Shared.Interop.IOKit
 
                     var terminateDelegate = new IONotificationPortCallback(TerminateNotification);
                     callback = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(terminateDelegate);
-                    result = NativeMethods.IOServiceAddMatchingNotification(NotificationPort.Handle, KIOTerminatedNotification, servicesDictionary.Handle, callback, System.IntPtr.Zero, out iterator);
+                    result = NativeMethods.IOServiceAddMatchingNotification(NotificationPort.Handle, KIOTerminatedNotification, servicesDictionary.Handle, callback, IntPtr.Zero, out iterator);
                     TerminateNotificationIterator = new IOIterator(iterator);
 
                     // The iterators returned when adding the matching notifications must be iterated to
@@ -349,9 +648,14 @@ namespace INTV.Shared.Interop.IOKit
 
                 NotificationPort.Dispose();
                 NotificationPort = null;
+
+                Interop.NativeMethods.CFRunLoopRemoveSource(CFRunLoop.Current, IOConnectionPort.NotificationPort.RunLoopSource, (NSString)CFRunLoop.ModeCommon);
+
+                IOConnectionPort.Dispose();
+                IOConnectionPort = null;
             }
 
-            private static void FirstMatchNotification(System.IntPtr refcon, System.IntPtr iteratorPtr)
+            private static void FirstMatchNotification(IntPtr refcon, IntPtr iteratorPtr)
             {
                 DebugOutput("IOService.IOKitNotificationPort: FirstMatchNotification");
                 var iterator = new IOIterator(iteratorPtr);
@@ -362,7 +666,7 @@ namespace INTV.Shared.Interop.IOKit
                 }
             }
 
-            private static void TerminateNotification(System.IntPtr refcon, System.IntPtr iteratorPtr)
+            private static void TerminateNotification(IntPtr refcon, IntPtr iteratorPtr)
             {
                 DebugOutput("IOService.IOKitNotificationPort: TerminateNotification");
                 var iterator = new IOIterator(iteratorPtr);
@@ -370,6 +674,113 @@ namespace INTV.Shared.Interop.IOKit
                 foreach (var port in newPorts)
                 {
                     ReportPortDeparture(port);
+                }
+            }
+
+            // see https://developer.apple.com/library/content/qa/qa1340/_index.html
+            // see https://developer.apple.com/documentation/iokit/1557114-ioregisterforsystempower?preferredLanguage=occ
+            private static void SystemPowerInterestCallback(IntPtr refcon, IntPtr service, uint messageType, IntPtr messageArgument)
+            {
+                var message = (IOMessage)messageType;
+                DebugOutput("IOService: SystemPowerInterestCallback: " + message);
+                var refconObject = (NSObject)Runtime.GetNSObject(refcon);
+                var serialPortNotifier = refconObject as IOKitNotificationPort;
+                switch (message)
+                {
+                    case IOMessage.KIOMessageCanSystemSleep:
+                        // From documentation for IORegisterForSystemPower
+                        // -----------------------------------------------
+                        // Indicates the system is pondering an idle sleep, but gives apps the chance to veto that sleep attempt.
+                        // Caller must acknowledge kIOMessageCanSystemSleep by calling IOAllowPowerChange or IOCancelPowerChange.
+                        // Calling IOAllowPowerChange will not veto the sleep; any app that calls IOCancelPowerChange will veto
+                        // the idle sleep. A kIOMessageCanSystemSleep notification will be followed up to 30 seconds later by
+                        // a kIOMessageSystemWillSleep message, or a kIOMessageSystemWillNotSleep message.
+                        // -----------------------------------------------
+
+                        // From example code:
+                        // ------------------
+                        // Idle sleep is about to kick in. This message will not be sent for forced sleep.
+                        // Applications have a chance to prevent sleep by calling IOCancelPowerChange.
+                        // Most applications should not prevent idle sleep.
+
+                        // Power Management waits up to 30 seconds for you to either allow or deny idle
+                        // sleep. If you don't acknowledge this power change by calling either
+                        // IOAllowPowerChange or IOCancelPowerChange, the system will wait 30
+                        // seconds then go to sleep.
+                        // ------------------
+                        var systemWillSleepArgs = new SystemWillSleepEventArgs(canCancel: true);
+                        serialPortNotifier.OnSystemWillSleep(systemWillSleepArgs);
+                        DebugOutput("IOService: SystemPowerInterestCallback: " + message + " CancelSleep: " + systemWillSleepArgs.Cancel);
+                        if (systemWillSleepArgs.Cancel)
+                        {
+                            serialPortNotifier.IOConnectionPort.CancelPowerChange((nint)messageArgument);
+                        }
+                        else
+                        {
+                            serialPortNotifier.IOConnectionPort.AllowPowerChange((nint)messageArgument);
+                        }
+                        break;
+                    case IOMessage.KIOMessageSystemWillSleep:
+                        // From documentation for IORegisterForSystemPower
+                        // -----------------------------------------------
+                        // Delivered at the point the system is initiating a non-abortable sleep.
+                        // Callers MUST acknowledge this event by calling IOAllowPowerChange.
+                        // If a caller does not acknowledge the sleep notification, the sleep will continue anyway
+                        // after a 30 second timeout (resulting in bad user experience). Delivered before any
+                        // hardware is powered off.
+                        // -----------------------------------------------
+
+                        // From example code:
+                        // ------------------
+                        // The system WILL go to sleep. If you do not call IOAllowPowerChange or
+                        // IOCancelPowerChange to acknowledge this message, sleep will be
+                        // delayed by 30 seconds.
+
+                        // NOTE: If you call IOCancelPowerChange to deny sleep it returns
+                        // kIOReturnSuccess, however the system WILL still go to sleep.
+                        // ------------------
+                        serialPortNotifier.OnSystemWillSleep(new SystemWillSleepEventArgs(canCancel: false));
+                        serialPortNotifier.IOConnectionPort.AllowPowerChange((nint)messageArgument);
+                        break;
+                    case IOMessage.KIOMessageSystemWillNotSleep:
+                        // From documentation for IORegisterForSystemPower
+                        // -----------------------------------------------
+                        // Delivered when some app client has vetoed an idle sleep request.
+                        // kIOMessageSystemWillNotSleep may follow a kIOMessageCanSystemSleep notification,
+                        // but will not otherwise be sent. Caller must NOT acknowledge kIOMessageSystemWillNotSleep;
+                        // the caller must simply return from its handler.
+                        // -----------------------------------------------
+                        break;
+                    case IOMessage.KIOMessageSystemWillPowerOn:
+                        // From documentation for IORegisterForSystemPower
+                        // -----------------------------------------------
+                        // Delivered at early wakeup time, before most hardware has been powered on.
+                        // Be aware that any attempts to access disk, network, the display, etc. may result in
+                        // errors or blocking your process until those resources become available. Caller
+                        // must NOT acknowledge kIOMessageSystemWillPowerOn; the caller must simply return from its handler.
+                        // -----------------------------------------------
+
+                        // From example code:
+                        // ------------------
+                        // System has started the wake up process...
+                        // ------------------
+                        break;
+                    case IOMessage.KIOMessageSystemHasPoweredOn:
+                        // From documentation for IORegisterForSystemPower
+                        // -----------------------------------------------
+                        // Delivered at wakeup completion time, after all device drivers and hardware have handled the wakeup event.
+                        // Expect this event 1-5 or more seconds after initiating system wakeup.
+                        // Caller must NOT acknowledge kIOMessageSystemHasPoweredOn; the caller must simply return from its handler.
+                        // -----------------------------------------------
+
+                        // From example code:
+                        // ------------------
+                        // System has finished waking up...
+                        // ------------------
+                        serialPortNotifier.OnSystemDidPowerOn();
+                        break;
+                    default:
+                        break;
                 }
             }
 
@@ -466,7 +877,7 @@ namespace INTV.Shared.Interop.IOKit
                         var nsData = NSData.FromString(val.Value);
                         return nsData;
                     default:
-                        System.Diagnostics.Debug.WriteLine("Unknown type: " + val.Name);
+                        DebugOutput("Unknown type: " + val.Name);
                         throw new ArgumentException("Unsupported");
                 }
             }


### PR DESCRIPTION
This is really only pertinent on Mac, which now uses IOKit bindings to better cope with power state changes. It will be able to deny sleep when serial port is busy, for example. This is significant because if the system cuts power to the port while it's in use, there are times when it induces a kernel panic on resuming power.