### PR TITLE
Add read block size and prevent sleep settings for Mac

### DIFF
--- a/INTV.LtoFlash/Properties/Settings.Designer.cs
+++ b/INTV.LtoFlash/Properties/Settings.Designer.cs
@@ -262,5 +262,29 @@ namespace INTV.LtoFlash.Properties {
                 this["VerifyVIDandPIDBeforeConnecting"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool PreventSystemSleepDuringDeviceCommands {
+            get {
+                return ((bool)(this["PreventSystemSleepDuringDeviceCommands"]));
+            }
+            set {
+                this["PreventSystemSleepDuringDeviceCommands"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int LtoFlashSerialReadChunkSize {
+            get {
+                return ((int)(this["LtoFlashSerialReadChunkSize"]));
+            }
+            set {
+                this["LtoFlashSerialReadChunkSize"] = value;
+            }
+        }
     }
 }

--- a/INTV.LtoFlash/Properties/Settings.Gtk.cs
+++ b/INTV.LtoFlash/Properties/Settings.Gtk.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="Settings.Gtk.cs" company="INTV Funhouse">
-// Copyright (c) 2017 All Rights Reserved
+// Copyright (c) 2017-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -20,6 +20,9 @@
 
 namespace INTV.LtoFlash.Properties
 {
+    /// <summary>
+    /// GTK-specific implementation.
+    /// </summary>
     internal sealed partial class Settings
     {
         /// <summary>
@@ -58,12 +61,25 @@ namespace INTV.LtoFlash.Properties
             set { SetSetting(MenuLayoutSaveDataColWidthSettingName, value); }
         }
 
+        /// <summary>
+        /// Gets or sets the serial port read block size to use.
+        /// </summary>
+        public int LtoFlashSerialReadChunkSize
+        {
+            get { return GetSetting<int>(LtoFlashSerialReadChunkSizeSettingName); }
+            set { SetSetting(LtoFlashSerialReadChunkSizeSettingName, value); }
+        }
+
+        /// <summary>
+        /// GTK-specific initialization.
+        /// </summary>
         partial void OSInitializeDefaults()
         {
             AddSetting(MenuLayoutLongNameColWidthSettingName, 256);
             AddSetting(MenuLayoutShortNameColWidthSettingName, 144);
             AddSetting(MenuLayoutManualColWidthSettingName, 168);
             AddSetting(MenuLayoutSaveDataColWidthSettingName, 128);
+            AddSetting(LtoFlashSerialReadChunkSizeSettingName, 0);
         }
     }
 }

--- a/INTV.LtoFlash/Properties/Settings.Mac.cs
+++ b/INTV.LtoFlash/Properties/Settings.Mac.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="Settings.Mac.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2017 All Rights Reserved
+// Copyright (c) 2014-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -18,6 +18,8 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 // </copyright>
 
+using INTV.Shared.Utility;
+
 namespace INTV.LtoFlash.Properties
 {
     /// <summary>
@@ -26,10 +28,73 @@ namespace INTV.LtoFlash.Properties
     internal sealed partial class Settings
     {
         /// <summary>
+        /// The name of the Locutus serial port write chunk size setting.
+        /// </summary>
+        public const string LtoFlashSerialWriteChunkSizeSettingName = "LtoFlashSerialWriteChunkSize";
+
+        /// <summary>
+        /// The minimum OS version requiring restricted read block sizes.
+        /// </summary>
+        public static readonly OSVersion OSVersionRequiringRestrictedReadBlockSize = new OSVersion(10, 13, 0);
+
+        /// <summary>
+        /// Gets the default size of the serial port read chunk in bytes.
+        /// </summary>
+        internal static int DefaultReadChunkSize
+        {
+            get
+            {
+                var defaultChunkSize = 0;
+                if (OSVersion.Current >= OSVersionRequiringRestrictedReadBlockSize)
+                {
+                    // It has been found that trying to read 'large' blocks from Locutus encounters timeout
+                    // errors. We suspect it's an inter-byte timeout problem -- possibly due to the out-of-band
+                    // bytes the FTDI serial interface uses. This has not been confirmed.
+                    // Further, the issue seems specific to macOS High Sierra (10.13) -- at least that was the
+                    // first macOS version against which the problem was reported and debugged.
+                    defaultChunkSize = 512;
+                }
+                return defaultChunkSize;
+            }
+        }
+
+        /// <summary>
+        /// Gets the default size of the serial port write chunk in bytes.
+        /// </summary>
+        internal static int DefaultWriteChunkSize
+        {
+            get
+            {
+                // Provisionally preparing for this...
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the serial port read block size to use.
+        /// </summary>
+        public int LtoFlashSerialReadChunkSize
+        {
+            get { return GetSetting<int>(LtoFlashSerialReadChunkSizeSettingName); }
+            set { SetSetting(LtoFlashSerialReadChunkSizeSettingName, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the serial port write block size to use.
+        /// </summary>
+        public int LtoFlashSerialWriteChunkSize
+        {
+            get { return GetSetting<int>(LtoFlashSerialWriteChunkSizeSettingName); }
+            set { SetSetting(LtoFlashSerialWriteChunkSizeSettingName, value); }
+        }
+
+        /// <summary>
         /// Mac-specific initialization.
         /// </summary>
         partial void OSInitializeDefaults()
         {
+            AddSetting(LtoFlashSerialReadChunkSizeSettingName, DefaultReadChunkSize);
+            AddSetting(LtoFlashSerialWriteChunkSizeSettingName, DefaultWriteChunkSize);
             InitializeUserDefaults();
         }
     }

--- a/INTV.LtoFlash/Properties/Settings.Mono.cs
+++ b/INTV.LtoFlash/Properties/Settings.Mono.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="Settings.Mono.cs" company="INTV Funhouse">
-// Copyright (c) 2017 All Rights Reserved
+// Copyright (c) 2017-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -162,6 +162,15 @@ namespace INTV.LtoFlash.Properties
             set { SetSetting(VerifyVIDandPIDBeforeConnectingSettingName, value); }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether to prevent system sleep during long-running commands.
+        /// </summary>
+        public bool PreventSystemSleepDuringDeviceCommands
+        {
+            get { return GetSetting<bool>(PreventSystemSleepDuringDeviceCommandsSettingName); }
+            set { SetSetting(PreventSystemSleepDuringDeviceCommandsSettingName, value); }
+        }
+
         #region ISettings
 
         /// <inheritdoc/>
@@ -182,6 +191,7 @@ namespace INTV.LtoFlash.Properties
             AddSetting(PromptToImportStarterRomsPropertyName, true);
             AddSetting(PromptForFirmwareUpgradeSettingName, true);
             AddSetting(VerifyVIDandPIDBeforeConnectingSettingName, true);
+            AddSetting(PreventSystemSleepDuringDeviceCommandsSettingName, false);
             OSInitializeDefaults();
         }
 

--- a/INTV.LtoFlash/Properties/Settings.cs
+++ b/INTV.LtoFlash/Properties/Settings.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="Settings.cs" company="INTV Funhouse">
-// Copyright (c) 2017 All Rights Reserved
+// Copyright (c) 2017-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -48,5 +48,7 @@ namespace INTV.LtoFlash.Properties
         public const string MenuLayoutShortNameColWidthSettingName = "MenuLayoutShortNameColWidth";
         public const string MenuLayoutManualColWidthSettingName = "MenuLayoutManualColWidth";
         public const string MenuLayoutSaveDataColWidthSettingName = "MenuLayoutSaveDataColWidth";
+        public const string PreventSystemSleepDuringDeviceCommandsSettingName = "PreventSystemSleepDuringDeviceCommands";
+        public const string LtoFlashSerialReadChunkSizeSettingName = "LtoFlashSerialReadChunkSize";
     }
 }

--- a/INTV.LtoFlash/Properties/Settings.settings
+++ b/INTV.LtoFlash/Properties/Settings.settings
@@ -62,5 +62,11 @@
     <Setting Name="VerifyVIDandPIDBeforeConnecting" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="PreventSystemSleepDuringDeviceCommands" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="LtoFlashSerialReadChunkSize" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/INTV.LtoFlash/View/SettingsPage.Mac.designer.cs
+++ b/INTV.LtoFlash/View/SettingsPage.Mac.designer.cs
@@ -6,8 +6,10 @@
 //
 
 #if __UNIFIED__
+using AppKit;
 using Foundation;
 #else
+using MonoMac.AppKit;
 using MonoMac.Foundation;
 #endif // __UNIFIED__
 
@@ -15,26 +17,33 @@ using System.CodeDom.Compiler;
 
 namespace INTV.LtoFlash.View
 {
-	[Register ("SettingsPage")]
-	partial class SettingsPage
-	{
-		
-		void ReleaseDesignerOutlets ()
-		{
-		}
-	}
-
 	[Register ("SettingsPageController")]
 	partial class SettingsPageController
 	{
+		[Outlet]
+		NSArrayController SerialPortReadChunkSizesArrayController { get; set; }
+
 		[Action ("_reconcileDeviceMenuToLocalMenu:")]
 		partial void _reconcileDeviceMenuToLocalMenu (NSObject sender);
 
 		[Action ("_searchAtStartupAction:")]
-		partial void _searchAtStartupAction (NSObject sender);
+        partial void _searchAtStartupAction (NSObject sender);
 
 		[Action ("_validateMenuAtStartupAction:")]
 		partial void _validateMenuAtStartupAction (NSObject sender);
+		
+		void ReleaseDesignerOutlets ()
+		{
+			if (SerialPortReadChunkSizesArrayController != null) {
+				SerialPortReadChunkSizesArrayController.Dispose ();
+				SerialPortReadChunkSizesArrayController = null;
+			}
+		}
+	}
+
+	[Register ("SettingsPage")]
+	partial class SettingsPage
+	{
 		
 		void ReleaseDesignerOutlets ()
 		{

--- a/INTV.LtoFlash/View/SettingsPage.xib
+++ b/INTV.LtoFlash/View/SettingsPage.xib
@@ -11,10 +11,17 @@
 			<string key="NS.object.0">3084</string>
 		</object>
 		<array key="IBDocument.IntegratedClassDependencies">
+			<string>NSArrayController</string>
 			<string>NSButton</string>
 			<string>NSButtonCell</string>
 			<string>NSCustomObject</string>
 			<string>NSCustomView</string>
+			<string>NSMenu</string>
+			<string>NSMenuItem</string>
+			<string>NSPopUpButton</string>
+			<string>NSPopUpButtonCell</string>
+			<string>NSTextField</string>
+			<string>NSTextFieldCell</string>
 			<string>NSUserDefaultsController</string>
 		</array>
 		<array key="IBDocument.PluginDependencies">
@@ -38,24 +45,161 @@
 				<reference key="NSNextResponder"/>
 				<int key="NSvFlags">268</int>
 				<array class="NSMutableArray" key="NSSubviews">
+					<object class="NSTextField" id="342070892">
+						<reference key="NSNextResponder" ref="159381209"/>
+						<int key="NSvFlags">289</int>
+						<string key="NSFrame">{{343, 0}, {110, 17}}</string>
+						<reference key="NSSuperview" ref="159381209"/>
+						<reference key="NSWindow"/>
+						<string key="NSReuseIdentifierKey">_NS:1535</string>
+						<bool key="NSEnabled">YES</bool>
+						<object class="NSTextFieldCell" key="NSCell" id="96007818">
+							<int key="NSCellFlags">68157504</int>
+							<int key="NSCellFlags2">71304192</int>
+							<string key="NSContents">* Indicates default value</string>
+							<object class="NSFont" key="NSSupport">
+								<string key="NSName">LucidaGrande</string>
+								<double key="NSSize">9</double>
+								<int key="NSfFlags">3614</int>
+							</object>
+							<string key="NSCellIdentifier">_NS:1535</string>
+							<reference key="NSControlView" ref="342070892"/>
+							<object class="NSColor" key="NSBackgroundColor" id="278623195">
+								<int key="NSColorSpace">6</int>
+								<string key="NSCatalogName">System</string>
+								<string key="NSColorName">controlColor</string>
+								<object class="NSColor" key="NSColor">
+									<int key="NSColorSpace">3</int>
+									<bytes key="NSWhite">MC42NjY2NjY2NjY3AA</bytes>
+								</object>
+							</object>
+							<object class="NSColor" key="NSTextColor" id="1062799988">
+								<int key="NSColorSpace">6</int>
+								<string key="NSCatalogName">System</string>
+								<string key="NSColorName">controlTextColor</string>
+								<object class="NSColor" key="NSColor">
+									<int key="NSColorSpace">3</int>
+									<bytes key="NSWhite">MAA</bytes>
+								</object>
+							</object>
+						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+					</object>
+					<object class="NSPopUpButton" id="206768740">
+						<reference key="NSNextResponder" ref="159381209"/>
+						<int key="NSvFlags">268</int>
+						<string key="NSFrame">{{248, 32}, {199, 26}}</string>
+						<reference key="NSSuperview" ref="159381209"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="342070892"/>
+						<string key="NSReuseIdentifierKey">_NS:9</string>
+						<bool key="NSEnabled">YES</bool>
+						<object class="NSPopUpButtonCell" key="NSCell" id="92560117">
+							<int key="NSCellFlags">-2076180416</int>
+							<int key="NSCellFlags2">2048</int>
+							<object class="NSFont" key="NSSupport" id="351977428">
+								<string key="NSName">LucidaGrande</string>
+								<double key="NSSize">13</double>
+								<int key="NSfFlags">1044</int>
+							</object>
+							<string key="NSCellIdentifier">_NS:9</string>
+							<reference key="NSControlView" ref="206768740"/>
+							<int key="NSButtonFlags">109199360</int>
+							<int key="NSButtonFlags2">129</int>
+							<string key="NSAlternateContents"/>
+							<string key="NSKeyEquivalent"/>
+							<int key="NSPeriodicDelay">400</int>
+							<int key="NSPeriodicInterval">75</int>
+							<object class="NSMenuItem" key="NSMenuItem" id="921800212">
+								<reference key="NSMenu" ref="30444943"/>
+								<string key="NSTitle">Item 1</string>
+								<string key="NSKeyEquiv"/>
+								<int key="NSKeyEquivModMask">1048576</int>
+								<int key="NSMnemonicLoc">2147483647</int>
+								<int key="NSState">1</int>
+								<object class="NSCustomResource" key="NSOnImage" id="457478172">
+									<string key="NSClassName">NSImage</string>
+									<string key="NSResourceName">NSMenuCheckmark</string>
+								</object>
+								<object class="NSCustomResource" key="NSMixedImage" id="65808598">
+									<string key="NSClassName">NSImage</string>
+									<string key="NSResourceName">NSMenuMixedState</string>
+								</object>
+								<string key="NSAction">_popUpItemAction:</string>
+								<reference key="NSTarget" ref="92560117"/>
+							</object>
+							<bool key="NSMenuItemRespectAlignment">YES</bool>
+							<object class="NSMenu" key="NSMenu" id="30444943">
+								<string key="NSTitle">OtherViews</string>
+								<array class="NSMutableArray" key="NSMenuItems">
+									<reference ref="921800212"/>
+									<object class="NSMenuItem" id="1071979045">
+										<reference key="NSMenu" ref="30444943"/>
+										<string key="NSTitle">Item 2</string>
+										<string key="NSKeyEquiv"/>
+										<int key="NSKeyEquivModMask">1048576</int>
+										<int key="NSMnemonicLoc">2147483647</int>
+										<reference key="NSOnImage" ref="457478172"/>
+										<reference key="NSMixedImage" ref="65808598"/>
+										<string key="NSAction">_popUpItemAction:</string>
+										<reference key="NSTarget" ref="92560117"/>
+									</object>
+									<object class="NSMenuItem" id="536133817">
+										<reference key="NSMenu" ref="30444943"/>
+										<string key="NSTitle">Item 3</string>
+										<string key="NSKeyEquiv"/>
+										<int key="NSKeyEquivModMask">1048576</int>
+										<int key="NSMnemonicLoc">2147483647</int>
+										<reference key="NSOnImage" ref="457478172"/>
+										<reference key="NSMixedImage" ref="65808598"/>
+										<string key="NSAction">_popUpItemAction:</string>
+										<reference key="NSTarget" ref="92560117"/>
+									</object>
+								</array>
+								<reference key="NSMenuFont" ref="351977428"/>
+							</object>
+							<int key="NSPreferredEdge">1</int>
+							<bool key="NSUsesItemFromMenu">YES</bool>
+							<bool key="NSAltersState">YES</bool>
+							<int key="NSArrowPosition">2</int>
+						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+					</object>
+					<object class="NSTextField" id="36211153">
+						<reference key="NSNextResponder" ref="159381209"/>
+						<int key="NSvFlags">268</int>
+						<string key="NSFrame">{{17, 37}, {228, 17}}</string>
+						<reference key="NSSuperview" ref="159381209"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="206768740"/>
+						<string key="NSReuseIdentifierKey">_NS:1535</string>
+						<bool key="NSEnabled">YES</bool>
+						<object class="NSTextFieldCell" key="NSCell" id="850318898">
+							<int key="NSCellFlags">68157504</int>
+							<int key="NSCellFlags2">272630784</int>
+							<string key="NSContents">Serial port data transfer size (read):</string>
+							<reference key="NSSupport" ref="351977428"/>
+							<string key="NSCellIdentifier">_NS:1535</string>
+							<reference key="NSControlView" ref="36211153"/>
+							<reference key="NSBackgroundColor" ref="278623195"/>
+							<reference key="NSTextColor" ref="1062799988"/>
+						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+					</object>
 					<object class="NSButton" id="55844880">
 						<reference key="NSNextResponder" ref="159381209"/>
 						<int key="NSvFlags">-2147483380</int>
-						<string key="NSFrame">{{18, 80}, {324, 18}}</string>
+						<string key="NSFrame">{{18, 60}, {324, 18}}</string>
 						<reference key="NSSuperview" ref="159381209"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="1033818597"/>
+						<reference key="NSNextKeyView" ref="36211153"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="456883080">
 							<int key="NSCellFlags">-2080374784</int>
 							<int key="NSCellFlags2">268435456</int>
 							<string key="NSContents">Perform file system maintenance in background</string>
-							<object class="NSFont" key="NSSupport" id="351977428">
-								<string key="NSName">LucidaGrande</string>
-								<double key="NSSize">13</double>
-								<int key="NSfFlags">1044</int>
-							</object>
+							<reference key="NSSupport" ref="351977428"/>
 							<string key="NSCellIdentifier">_NS:9</string>
 							<reference key="NSControlView" ref="55844880"/>
 							<int key="NSButtonFlags">1211912448</int>
@@ -74,13 +218,40 @@
 						</object>
 						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
+					<object class="NSButton" id="325547173">
+						<reference key="NSNextResponder" ref="159381209"/>
+						<int key="NSvFlags">268</int>
+						<string key="NSFrame">{{18, 80}, {285, 18}}</string>
+						<reference key="NSSuperview" ref="159381209"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="55844880"/>
+						<string key="NSReuseIdentifierKey">_NS:9</string>
+						<bool key="NSEnabled">YES</bool>
+						<object class="NSButtonCell" key="NSCell" id="839925220">
+							<int key="NSCellFlags">-2080374784</int>
+							<int key="NSCellFlags2">268435456</int>
+							<string key="NSContents">Prevent system sleep during data transfer</string>
+							<reference key="NSSupport" ref="351977428"/>
+							<string key="NSCellIdentifier">_NS:9</string>
+							<reference key="NSControlView" ref="325547173"/>
+							<int key="NSButtonFlags">1211912448</int>
+							<int key="NSButtonFlags2">2</int>
+							<reference key="NSNormalImage" ref="171818902"/>
+							<reference key="NSAlternateImage" ref="852701397"/>
+							<string key="NSAlternateContents"/>
+							<string key="NSKeyEquivalent"/>
+							<int key="NSPeriodicDelay">200</int>
+							<int key="NSPeriodicInterval">25</int>
+						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+					</object>
 					<object class="NSButton" id="930714162">
 						<reference key="NSNextResponder" ref="159381209"/>
 						<int key="NSvFlags">268</int>
 						<string key="NSFrame">{{18, 100}, {348, 18}}</string>
 						<reference key="NSSuperview" ref="159381209"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="55844880"/>
+						<reference key="NSNextKeyView" ref="325547173"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="955871144">
@@ -242,7 +413,7 @@
 						<string key="NSFrame">{{18, 220}, {399, 18}}</string>
 						<reference key="NSSuperview" ref="159381209"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
+						<reference key="NSNextKeyView" ref="168646716"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="570715146">
@@ -269,7 +440,7 @@
 						<string key="NSFrame">{{18, 240}, {326, 18}}</string>
 						<reference key="NSSuperview" ref="159381209"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="168646716"/>
+						<reference key="NSNextKeyView" ref="1033818597"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="245195014">
@@ -327,6 +498,15 @@
 			<object class="NSUserDefaultsController" id="578309286">
 				<bool key="NSSharedInstance">YES</bool>
 			</object>
+			<object class="NSArrayController" id="490027127">
+				<bool key="NSEditable">YES</bool>
+				<object class="_NSManagedProxy" key="_NSManagedProxy"/>
+				<bool key="NSAvoidsEmptySelection">YES</bool>
+				<bool key="NSPreservesSelection">YES</bool>
+				<bool key="NSSelectsInsertedObjects">YES</bool>
+				<bool key="NSFilterRestrictsInsertion">YES</bool>
+				<bool key="NSClearsFilterPredicateOnInsertion">YES</bool>
+			</object>
 			<object class="NSCustomObject" id="1009614913">
 				<string key="NSClassName">NSObject</string>
 			</object>
@@ -340,6 +520,14 @@
 						<reference key="destination" ref="159381209"/>
 					</object>
 					<int key="connectionID">17</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">SerialPortReadChunkSizesArrayController</string>
+						<reference key="source" ref="1001"/>
+						<reference key="destination" ref="490027127"/>
+					</object>
+					<int key="connectionID">102</int>
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBBindingConnection" key="connection">
@@ -501,6 +689,72 @@
 					</object>
 					<int key="connectionID">96</int>
 				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">value: values.PreventSystemSleepDuringDeviceCommands</string>
+						<reference key="source" ref="325547173"/>
+						<reference key="destination" ref="578309286"/>
+						<object class="NSNibBindingConnector" key="connector">
+							<reference key="NSSource" ref="325547173"/>
+							<reference key="NSDestination" ref="578309286"/>
+							<string key="NSLabel">value: values.PreventSystemSleepDuringDeviceCommands</string>
+							<string key="NSBinding">value</string>
+							<string key="NSKeyPath">values.PreventSystemSleepDuringDeviceCommands</string>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">100</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">content: arrangedObjects</string>
+						<reference key="source" ref="206768740"/>
+						<reference key="destination" ref="490027127"/>
+						<object class="NSNibBindingConnector" key="connector" id="915052503">
+							<reference key="NSSource" ref="206768740"/>
+							<reference key="NSDestination" ref="490027127"/>
+							<string key="NSLabel">content: arrangedObjects</string>
+							<string key="NSBinding">content</string>
+							<string key="NSKeyPath">arrangedObjects</string>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">118</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">contentValues: arrangedObjects.DisplayName</string>
+						<reference key="source" ref="206768740"/>
+						<reference key="destination" ref="490027127"/>
+						<object class="NSNibBindingConnector" key="connector" id="973796177">
+							<reference key="NSSource" ref="206768740"/>
+							<reference key="NSDestination" ref="490027127"/>
+							<string key="NSLabel">contentValues: arrangedObjects.DisplayName</string>
+							<string key="NSBinding">contentValues</string>
+							<string key="NSKeyPath">arrangedObjects.DisplayName</string>
+							<reference key="NSPreviousConnector" ref="915052503"/>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">119</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">selectedIndex: SelectedReadChunkSize</string>
+						<reference key="source" ref="206768740"/>
+						<reference key="destination" ref="1001"/>
+						<object class="NSNibBindingConnector" key="connector">
+							<reference key="NSSource" ref="206768740"/>
+							<reference key="NSDestination" ref="1001"/>
+							<string key="NSLabel">selectedIndex: SelectedReadChunkSize</string>
+							<string key="NSBinding">selectedIndex</string>
+							<string key="NSKeyPath">SelectedReadChunkSize</string>
+							<reference key="NSPreviousConnector" ref="973796177"/>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">120</int>
+				</object>
 			</array>
 			<object class="IBMutableOrderedSet" key="objectRecords">
 				<array key="orderedObjects">
@@ -542,6 +796,10 @@
 							<reference ref="168646716"/>
 							<reference ref="55844880"/>
 							<reference ref="1033818597"/>
+							<reference ref="325547173"/>
+							<reference ref="36211153"/>
+							<reference ref="206768740"/>
+							<reference ref="342070892"/>
 						</array>
 						<reference key="parent" ref="0"/>
 					</object>
@@ -552,6 +810,7 @@
 							<reference ref="89588230"/>
 						</array>
 						<reference key="parent" ref="159381209"/>
+						<string key="objectName">SearchForAttachedDevicesAtStartup</string>
 					</object>
 					<object class="IBObjectRecord">
 						<int key="objectID">19</int>
@@ -565,6 +824,7 @@
 							<reference ref="371473887"/>
 						</array>
 						<reference key="parent" ref="159381209"/>
+						<string key="objectName">ValidateLocalMenuAtStartup</string>
 					</object>
 					<object class="IBObjectRecord">
 						<int key="objectID">21</int>
@@ -578,6 +838,7 @@
 							<reference ref="199980472"/>
 						</array>
 						<reference key="parent" ref="159381209"/>
+						<string key="objectName">ReconcileDeviceMenuWithLocalMenu</string>
 					</object>
 					<object class="IBObjectRecord">
 						<int key="objectID">23</int>
@@ -596,6 +857,7 @@
 							<reference ref="245195014"/>
 						</array>
 						<reference key="parent" ref="159381209"/>
+						<string key="objectName">AutomaticallyConnectToDevicesWhenDetected</string>
 					</object>
 					<object class="IBObjectRecord">
 						<int key="objectID">70</int>
@@ -609,6 +871,7 @@
 							<reference ref="456883080"/>
 						</array>
 						<reference key="parent" ref="159381209"/>
+						<string key="objectName">PerformBackgroundFileMaintenance</string>
 					</object>
 					<object class="IBObjectRecord">
 						<int key="objectID">72</int>
@@ -622,6 +885,7 @@
 							<reference ref="285312562"/>
 						</array>
 						<reference key="parent" ref="159381209"/>
+						<string key="objectName">PromptToAddRomsToMenu</string>
 					</object>
 					<object class="IBObjectRecord">
 						<int key="objectID">78</int>
@@ -635,6 +899,7 @@
 							<reference ref="745103262"/>
 						</array>
 						<reference key="parent" ref="159381209"/>
+						<string key="objectName">AddRomsToMenu</string>
 					</object>
 					<object class="IBObjectRecord">
 						<int key="objectID">80</int>
@@ -648,6 +913,7 @@
 							<reference ref="80922446"/>
 						</array>
 						<reference key="parent" ref="159381209"/>
+						<string key="objectName">EnableSerialPortLogging</string>
 					</object>
 					<object class="IBObjectRecord">
 						<int key="objectID">85</int>
@@ -667,6 +933,7 @@
 							<reference ref="955871144"/>
 						</array>
 						<reference key="parent" ref="159381209"/>
+						<string key="objectName">PromptForFirmwareUpdateOnConnect</string>
 					</object>
 					<object class="IBObjectRecord">
 						<int key="objectID">90</int>
@@ -680,11 +947,102 @@
 							<reference ref="570715146"/>
 						</array>
 						<reference key="parent" ref="159381209"/>
+						<string key="objectName">OnlyConnectToLtoFlashDevices</string>
 					</object>
 					<object class="IBObjectRecord">
 						<int key="objectID">94</int>
 						<reference key="object" ref="570715146"/>
 						<reference key="parent" ref="1033818597"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">97</int>
+						<reference key="object" ref="325547173"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="839925220"/>
+						</array>
+						<reference key="parent" ref="159381209"/>
+						<string key="objectName">PreventSleepDuringOperations</string>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">98</int>
+						<reference key="object" ref="839925220"/>
+						<reference key="parent" ref="325547173"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">101</int>
+						<reference key="object" ref="490027127"/>
+						<reference key="parent" ref="0"/>
+						<string key="objectName">SerialPortReadChunkSizesArrayController</string>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">103</int>
+						<reference key="object" ref="36211153"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="850318898"/>
+						</array>
+						<reference key="parent" ref="159381209"/>
+						<string key="objectName">SerialReadChunkSizeLabel</string>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">104</int>
+						<reference key="object" ref="850318898"/>
+						<reference key="parent" ref="36211153"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">105</int>
+						<reference key="object" ref="206768740"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="92560117"/>
+						</array>
+						<reference key="parent" ref="159381209"/>
+						<string key="objectName">SerialReadChunkSize</string>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">106</int>
+						<reference key="object" ref="92560117"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="30444943"/>
+						</array>
+						<reference key="parent" ref="206768740"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">107</int>
+						<reference key="object" ref="30444943"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="921800212"/>
+							<reference ref="1071979045"/>
+							<reference ref="536133817"/>
+						</array>
+						<reference key="parent" ref="92560117"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">108</int>
+						<reference key="object" ref="921800212"/>
+						<reference key="parent" ref="30444943"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">109</int>
+						<reference key="object" ref="1071979045"/>
+						<reference key="parent" ref="30444943"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">110</int>
+						<reference key="object" ref="536133817"/>
+						<reference key="parent" ref="30444943"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">121</int>
+						<reference key="object" ref="342070892"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="96007818"/>
+						</array>
+						<reference key="parent" ref="159381209"/>
+						<string key="objectName">DefaultValueLabel</string>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">122</int>
+						<reference key="object" ref="96007818"/>
+						<reference key="parent" ref="342070892"/>
 					</object>
 				</array>
 			</object>
@@ -692,6 +1050,17 @@
 				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="-3.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="101.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="103.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="104.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="105.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="106.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="107.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="108.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="109.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="110.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="121.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="122.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="18.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="18.userInterfaceItemIdentifier">SearchForDevicesAtStartup</string>
 				<string key="19.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -757,12 +1126,14 @@ A</bytes>
 				<string key="93.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="93.userInterfaceItemIdentifier">VerifyVIDandPIDBeforeConnecting</string>
 				<string key="94.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="97.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="98.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 			</dictionary>
 			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">96</int>
+			<int key="maxID">122</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -796,6 +1167,17 @@ A</bytes>
 							<string key="candidateClassName">id</string>
 						</object>
 					</dictionary>
+					<object class="NSMutableDictionary" key="outlets">
+						<string key="NS.key.0">SerialPortReadChunkSizesArrayController</string>
+						<string key="NS.object.0">NSArrayController</string>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<string key="NS.key.0">SerialPortReadChunkSizesArrayController</string>
+						<object class="IBToOneOutletInfo" key="NS.object.0">
+							<string key="name">SerialPortReadChunkSizesArrayController</string>
+							<string key="candidateClassName">NSArrayController</string>
+						</object>
+					</object>
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
 						<string key="majorKey">IBProjectSource</string>
 						<string key="minorKey">./Classes/SettingsPageController.h</string>
@@ -815,9 +1197,10 @@ A</bytes>
 		</object>
 		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
 		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<object class="NSMutableDictionary" key="IBDocument.LastKnownImageSizes">
-			<string key="NS.key.0">NSSwitch</string>
-			<string key="NS.object.0">{15, 15}</string>
-		</object>
+		<dictionary class="NSMutableDictionary" key="IBDocument.LastKnownImageSizes">
+			<string key="NSMenuCheckmark">{11, 11}</string>
+			<string key="NSMenuMixedState">{10, 3}</string>
+			<string key="NSSwitch">{15, 15}</string>
+		</dictionary>
 	</data>
 </archive>

--- a/INTV.LtoFlash/View/SettingsPageController.Mac.cs
+++ b/INTV.LtoFlash/View/SettingsPageController.Mac.cs
@@ -1,5 +1,5 @@
 // <copyright file="SettingsPageController.Mac.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2017 All Rights Reserved
+// Copyright (c) 2014-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -20,6 +20,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using INTV.LtoFlash.ViewModel;
+using INTV.Shared.Utility;
 using INTV.Shared.View;
 #if __UNIFIED__
 using AppKit;
@@ -106,10 +108,47 @@ namespace INTV.LtoFlash.View
 
         #endregion // IFakeDependencyObject
 
+        /// <summary>
+        /// Gets or sets the serial port read chunk size.
+        /// </summary>
+        [INTV.Shared.Utility.OSExport("SelectedReadChunkSize")]
+        public NSNumber SelectedReadChunkSize
+        {
+            get
+            {
+                if (!_initializedReadChunkSizes)
+                {
+                    var selectedChunkSizeViewModel = ViewModel.SelectedReadChunkSizeViewModel;
+                    var selectedChunkSize = selectedChunkSizeViewModel.BlockSize;
+                    var selectionIndex = ViewModel.AvailableSerialPortReadBlockSizes.IndexOf(selectedChunkSizeViewModel);
+                    if (selectionIndex < SerialPortReadChunkSizesArrayController.ArrangedObjects().Length)
+                    {
+                        _selectedReadChunkSize = selectionIndex;
+                    }
+                }
+                return _selectedReadChunkSize;
+            }
+
+            set
+            {
+                _selectedReadChunkSize = value;
+                ViewModel.SelectedReadChunkSizeViewModel = ViewModel.AvailableSerialPortReadBlockSizes[_selectedReadChunkSize.Int32Value];
+            }
+        }
+        private NSNumber _selectedReadChunkSize;
+        private bool _initializedReadChunkSizes;
+
+        private SettingsPageViewModel ViewModel
+        {
+            get { return DataContext as SettingsPageViewModel; }
+        } 
+
         /// <inheritdoc />
         public override void AwakeFromNib()
         {
             View.Controller = this;
+            SerialPortReadChunkSizesArrayController.SynchronizeCollection(ViewModel.AvailableSerialPortReadBlockSizes);
+            _initializedReadChunkSizes = true;
         }
     }
 }

--- a/INTV.LtoFlash/ViewModel/SettingsPageViewModel.Mac.cs
+++ b/INTV.LtoFlash/ViewModel/SettingsPageViewModel.Mac.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="SettingsPageViewModel.Mac.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2017 All Rights Reserved
+// Copyright (c) 2014-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -18,6 +18,12 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 // </copyright>
 
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using INTV.Shared.Utility;
+using INTV.Shared.ViewModel;
+
 #if __UNIFIED__
 using Foundation;
 #else
@@ -31,12 +37,71 @@ namespace INTV.LtoFlash.ViewModel
     /// </summary>
     public sealed partial class SettingsPageViewModel
     {
-        private void Initialize()
+        /// <summary>
+        /// The name of the serial port read chunk size property.
+        /// </summary>
+        public const string SerialPortReadChunkSizePropertyName = "SerialPortReadChunkSize";
+
+        /// <summary>
+        /// Gets the available serial port read block sizes.
+        /// </summary>
+        public ObservableCollection<SerialPortReadWriteBlockSizeViewModel> AvailableSerialPortReadBlockSizes { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the selected read chunk size ViewModel.
+        /// </summary>
+        public SerialPortReadWriteBlockSizeViewModel SelectedReadChunkSizeViewModel
         {
-            var settings = NSUserDefaults.StandardUserDefaults;
-            _searchForDevicesAtStartup = settings.BoolForKey("SearchForDevicesAtStartup");
-            _validateMenuAtLaunch = settings.BoolForKey("ValidateMenuAtStartup");
-            _reconcileDeviceMenuWithLocalMenu = settings.BoolForKey("ReconcileDeviceMenuWithLocalMenu");
+            get { return _selectedReadChunkSizeViewModel; }
+            set { AssignAndUpdateProperty("SelectedReadChunkSizeViewModel", value, ref _selectedReadChunkSizeViewModel, (p, v) => UpdateReadChunkSize(v.BlockSize)); }
+        }
+        private SerialPortReadWriteBlockSizeViewModel _selectedReadChunkSizeViewModel;
+
+        /// <summary>
+        /// Gets or sets the serial port read chunk size.
+        /// </summary>
+        [OSExport(SerialPortReadChunkSizePropertyName)]
+        public int SerialPortReadChunkSize
+        {
+            get { return _serialPortReadChunkSize; }
+            set { AssignAndUpdateProperty(SerialPortReadChunkSizePropertyName, value, ref _serialPortReadChunkSize); }
+        }
+        private int _serialPortReadChunkSize;
+
+        private void UpdateReadChunkSize(int chunkSize)
+        {
+            SerialPortReadChunkSize = chunkSize;
+            Properties.Settings.Default.LtoFlashSerialReadChunkSize = chunkSize;
+        }
+
+        private string GetDisplayNameForByteSize(int readBlockSize, int defaultChunkSize)
+        {
+            var suffix = readBlockSize == defaultChunkSize ? " *" : string.Empty;
+            var displayName = string.Empty;
+            if (readBlockSize == 0)
+            {
+                displayName = "As requested";
+            }
+            else
+            {
+                displayName = string.Format(System.Globalization.CultureInfo.CurrentCulture, "{0} bytes", readBlockSize);
+            }
+            return displayName + suffix;
+        }
+
+        /// <summary>
+        /// Initialize Mac-specific settings.
+        /// </summary>
+        partial void OSInitialize()
+        {
+            var readBlockSizes = new[] { 0, 768, 512, 256, 128, 64 };
+            AvailableSerialPortReadBlockSizes = new ObservableCollection<SerialPortReadWriteBlockSizeViewModel>(readBlockSizes.Select(s => new SerialPortReadWriteBlockSizeViewModel(s, GetDisplayNameForByteSize(s, Properties.Settings.DefaultReadChunkSize))));
+            _selectedReadChunkSizeViewModel = AvailableSerialPortReadBlockSizes.FirstOrDefault(s => s.BlockSize == Properties.Settings.Default.LtoFlashSerialReadChunkSize);
+            if (_selectedReadChunkSizeViewModel == null)
+            {
+                _selectedReadChunkSizeViewModel = AvailableSerialPortReadBlockSizes.First(s => s.BlockSize == Properties.Settings.DefaultReadChunkSize);
+            }
+            _serialPortReadChunkSize = _selectedReadChunkSizeViewModel.BlockSize;
         }
     }
 }

--- a/INTV.LtoFlash/ViewModel/SettingsPageViewModel.cs
+++ b/INTV.LtoFlash/ViewModel/SettingsPageViewModel.cs
@@ -93,6 +93,7 @@ namespace INTV.LtoFlash.ViewModel
             _promptToUpgradeFirmware = Properties.Settings.Default.PromptForFirmwareUpgrade;
             _showFileSystemDetails = Properties.Settings.Default.ShowFileSystemDetails;
             _showAdvancedFeatures = Properties.Settings.Default.ShowAdvancedFeatures;
+            OSInitialize();
         }
 
         #region EnableAdvancedFeaturesCommand
@@ -265,5 +266,10 @@ namespace INTV.LtoFlash.ViewModel
         protected override void RaiseAllPropertiesChanged()
         {
         }
+
+        /// <summary>
+        /// Operating-system-specific initialization.
+        /// </summary>
+        partial void OSInitialize();
     }
 }

--- a/INTV.LtoFlash/app.config
+++ b/INTV.LtoFlash/app.config
@@ -67,6 +67,12 @@
             <setting name="VerifyVIDandPIDBeforeConnecting" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="PreventSystemSleepDuringDeviceCommands" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="LtoFlashSerialReadChunkSize" serializeAs="String">
+                <value>0</value>
+            </setting>
         </INTV.LtoFlash.Properties.Settings>
     </userSettings>
 </configuration>

--- a/INTV.Shared/INTV.Shared.Gtk.csproj
+++ b/INTV.Shared/INTV.Shared.Gtk.csproj
@@ -310,6 +310,7 @@
     <Compile Include="..\VersionInfo.cs">
       <Link>Properties\VersionInfo.cs</Link>
     </Compile>
+    <Compile Include="ViewModel\SerialPortReadWriteBlockSizeViewModel.cs" />
     <Compile Include="Interop\DeviceManagement\ISystemPowerManagement.cs" />
     <Compile Include="Interop\DeviceManagement\SystemWillSleepEventArgs.cs" />
   </ItemGroup>

--- a/INTV.Shared/INTV.Shared.Mac.csproj
+++ b/INTV.Shared/INTV.Shared.Mac.csproj
@@ -384,6 +384,7 @@
     <Compile Include="Interop\IOKit\IOMessage.cs" />
     <Compile Include="Interop\DeviceManagement\ISystemPowerManagement.cs" />
     <Compile Include="Interop\DeviceManagement\SystemWillSleepEventArgs.cs" />
+    <Compile Include="ViewModel\SerialPortReadWriteBlockSizeViewModel.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Mono\MonoMac\v0.0\Mono.MonoMac.targets" />

--- a/INTV.Shared/INTV.Shared.VSMac.csproj
+++ b/INTV.Shared/INTV.Shared.VSMac.csproj
@@ -382,6 +382,7 @@
     <Compile Include="Interop\DeviceManagement\SystemWillSleepEventArgs.cs" />
     <Compile Include="Interop\IOKit\IOConnect.cs" />
     <Compile Include="Interop\IOKit\IOMessage.cs" />
+    <Compile Include="ViewModel\SerialPortReadWriteBlockSizeViewModel.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\INTV.jzIntv\INTV.jzIntv.VSMac.csproj">

--- a/INTV.Shared/INTV.Shared.XamMac.csproj
+++ b/INTV.Shared/INTV.Shared.XamMac.csproj
@@ -382,6 +382,7 @@
     <Compile Include="Interop\DeviceManagement\SystemWillSleepEventArgs.cs" />
     <Compile Include="Interop\IOKit\IOConnect.cs" />
     <Compile Include="Interop\IOKit\IOMessage.cs" />
+    <Compile Include="ViewModel\SerialPortReadWriteBlockSizeViewModel.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\INTV.jzIntv\INTV.jzIntv.XamMac.csproj">

--- a/INTV.Shared/INTV.Shared.desktop.csproj
+++ b/INTV.Shared/INTV.Shared.desktop.csproj
@@ -248,6 +248,7 @@
     <Compile Include="Utility\StopBitsHelpers.cs" />
     <Compile Include="Utility\StorageAccess.cs" />
     <Compile Include="ViewModel\OSViewModelBase.WPF.cs" />
+    <Compile Include="ViewModel\SerialPortReadWriteBlockSizeViewModel.cs" />
     <Compile Include="View\IMainWindow.cs" />
     <Compile Include="View\OSMenuItem.cs" />
     <Compile Include="View\OSMenuItem.WPF.cs" />

--- a/INTV.Shared/INTV.Shared.xp.csproj
+++ b/INTV.Shared/INTV.Shared.xp.csproj
@@ -228,6 +228,7 @@
     <Compile Include="Utility\StopBitsHelpers.cs" />
     <Compile Include="Utility\StorageAccess.cs" />
     <Compile Include="ViewModel\OSViewModelBase.WPF.cs" />
+    <Compile Include="ViewModel\SerialPortReadWriteBlockSizeViewModel.cs" />
     <Compile Include="View\IMainWindow.cs" />
     <Compile Include="View\OSMenuItem.cs" />
     <Compile Include="View\OSMenuItem.WPF.cs" />

--- a/INTV.Shared/ViewModel/SerialPortReadWriteBlockSizeViewModel.cs
+++ b/INTV.Shared/ViewModel/SerialPortReadWriteBlockSizeViewModel.cs
@@ -1,0 +1,50 @@
+﻿// <copyright file="SerialPortReadWriteBlockSizeViewModel.cs" company="INTV Funhouse">
+// Copyright (c) 2018 All Rights Reserved
+// <author>Steven A. Orth</author>
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this software. If not, see: http://www.gnu.org/licenses/.
+// or write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+// </copyright>
+
+namespace INTV.Shared.ViewModel
+{
+    /// <summary>
+    /// ViewModel for serial port read or write block size.
+    /// </summary>
+    public class SerialPortReadWriteBlockSizeViewModel : OSViewModelBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="INTV.Shared.ViewModel.SerialPortReadWriteBlockSizeViewModel"/> class.
+        /// </summary>
+        /// <param name="blockSize">Block size (in bytes is implied).</param>
+        /// <param name="displayName">Localized display name.</param>
+        public SerialPortReadWriteBlockSizeViewModel(int blockSize, string displayName)
+        {
+            BlockSize = blockSize;
+            DisplayName = displayName;
+        }
+
+        /// <summary>
+        /// Gets the display name for the block size.
+        /// </summary>
+        [INTV.Shared.Utility.OSExportAttribute("DisplayName")]
+        public string DisplayName { get; private set; }
+
+        /// <summary>
+        /// Gets the block size in bytes (implied).
+        /// </summary>
+        public int BlockSize { get; private set; }
+    }
+}


### PR DESCRIPTION
The read chunk size is necessary to get things working on macOS High Sierra (10.13) which seems to have simply broken the ability to read >512 bytes on a serial port reliably -- at least for the FTDI chip on **_LTO Flash!_**.