### PR TITLE
Fix serial reads for macOS High Sierra

### DIFF
--- a/INTV.LtoFlash/Model/DeviceHelpers.cs
+++ b/INTV.LtoFlash/Model/DeviceHelpers.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="DeviceHelpers.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2017 All Rights Reserved
+// Copyright (c) 2014-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
 
 using System;
 using System.Linq;
+using INTV.LtoFlash.Model.Commands;
 using INTV.Shared.Model;
 using INTV.Shared.Utility;
 
@@ -90,18 +91,21 @@ namespace INTV.LtoFlash.Model
             var desiredCharacterIndex = 0;
             try
             {
-                do
+                using (port.SetInUse(ProtocolCommand.UpdatePortChunkSizeConfigurations))
                 {
-                    var desiredCharacter = Device.BeaconCharacters[desiredCharacterIndex];
-                    var character = reader.ReadChar();
-                    port.LogPortMessage("WaitForBeacon received: '" + character + "'");
-                    if (character == desiredCharacter)
+                    do
                     {
-                        ++desiredCharacterIndex;
-                        detectedBeacon = character == Device.BeaconCharacters.Last();
+                        var desiredCharacter = Device.BeaconCharacters[desiredCharacterIndex];
+                        var character = reader.ReadChar();
+                        port.LogPortMessage("WaitForBeacon received: '" + character + "'");
+                        if (character == desiredCharacter)
+                        {
+                            ++desiredCharacterIndex;
+                            detectedBeacon = character == Device.BeaconCharacters.Last();
+                        }
                     }
+                    while (!detectedBeacon);
                 }
-                while (!detectedBeacon);
             }
             catch (TimeoutException)
             {

--- a/INTV.LtoFlash/ViewModel/LtoFlashViewModel.Mac.cs
+++ b/INTV.LtoFlash/ViewModel/LtoFlashViewModel.Mac.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="LtoFlashViewModel.Mac.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2016 All Rights Reserved
+// Copyright (c) 2014-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -48,6 +48,8 @@ namespace INTV.LtoFlash.ViewModel
         partial void OSInitialize()
         {
             _showFTDIWarning = OSVersion.Current < Configuration.Instance.RecommendedOSVersion;
+            var readChunkSize = Properties.Settings.Default.LtoFlashSerialReadChunkSize;
+            INTV.LtoFlash.Model.Commands.DownloadDataBlockFromRam.ReadChunkSize = readChunkSize;
 #if ENABLE_COLORS_PATCH
             _fixColors = new FixColorsList();
             _fixColors.Register();


### PR DESCRIPTION
These changes finish implementing the 'port in use' and 'nibbly reads' for reading blocks of RAM from the _**LTO Flash!**_ that somehow broke in macOS 10.13 (High Sierra).