### PR TITLE
For installer source and Mac installer to work for Git repos, need to

### DIFF
--- a/Locutus/Installer.Mac/installer.mak
+++ b/Locutus/Installer.Mac/installer.mak
@@ -19,6 +19,7 @@
 # This makefile is in a subdirectory, so set ROOT_DIR accordingly.
 # ------------------------------------------------------------------------- #
 ROOT_DIR = ../..
+VERSION_CS_CLASS_OUTPUT_DIR = $(ROOT_DIR)
 
 include $(ROOT_DIR)/version.mak
 

--- a/Locutus/Installer.source/installer.source.mak
+++ b/Locutus/Installer.source/installer.source.mak
@@ -9,6 +9,7 @@
 # This makefile is in a subdirectory, so set ROOT_DIR accordingly.
 # ------------------------------------------------------------------------- #
 ROOT_DIR = ../..
+VERSION_CS_CLASS_OUTPUT_DIR = $(ROOT_DIR)
 
 include $(ROOT_DIR)/version.mak
 


### PR DESCRIPTION
specify the VERSION_CS_CLASS_OUTPUT_DIR path so the build can fetch
the version number properly.