### PR TITLE
Add credentials support

### DIFF
--- a/Locutus/Installer.source/installer.source.mak
+++ b/Locutus/Installer.source/installer.source.mak
@@ -24,6 +24,8 @@ include $(ROOT_DIR)/version.mak
 #                     and retrieve source code
 #   GIT_REPO        : if specified, used to retrieve source code
 #   GIT_REPO_REMOTE : OPTIONAL indicate support for 'svn export' using Git
+#   GIT_USERNAME    : OPTIONAL used for svn export when GIT_REPO_REMOTE is 1
+#   GIT_PASSPHRASE  : OPTIONAL used for svn export when GIT_REPO_REMOTE is 1
 # ------------------------------------------------------------------------- #
 
 # ------------------------------------------------------------------------- #
@@ -64,6 +66,13 @@ ifneq (,$(GIT_REPO))
     SVN_REPO := $(GIT_REPO)
     SOURCE_DIR := $(SVN_REPO)
     GIT_REPO := 
+    SVN_CREDENTIALS := 
+    ifneq ($(GIT_USERNAME),)
+      SVN_CREDENTIALS += --username $(GIT_USERNAME)
+    endif
+    ifneq ($(GIT_PASSPHRASE),)
+      SVN_CREDENTIALS += --password $(GIT_PASSPHRASE)
+    endif
   else
     # --------------------------------------------------------------------- #
     # It's assumed $(CURDIR) is the directory containing this makefile, and that
@@ -177,7 +186,7 @@ $(TARGET_DIR):
 	@echo
 	@echo --------------------- Exporting Source From Repo ---------------------
 	@echo ... Exporting from $(SOURCE_DIR) ...
-	svn export $(SOURCE_DIR) $(TARGET_DIR)
+	svn export $(SVN_CREDENTIALS) $(SOURCE_DIR) $(TARGET_DIR)
 	@rm -f $(TARGET_DIR)/.gitattributes
 	@rm -f $(TARGET_DIR)/.gitignore
 

--- a/custom.mak.template
+++ b/custom.mak.template
@@ -49,6 +49,15 @@ ifeq ($(findstring https://github.com/,$(GIT_REPO)),https://github.com/)
 endif
 
 # ------------------------------------------------------------------------- #
+# Git Authentication
+# ------------------------------------------------------------------------- #
+# You may need a git user name for some operations, such as creating the
+# source installer, which uses svn commands.
+# ------------------------------------------------------------------------- #
+GIT_USERNAME ?= 
+GIT_PASSPHRASE ?=
+
+# ------------------------------------------------------------------------- #
 # Repository Validation
 # ------------------------------------------------------------------------- #
 # Only one source control repository at a time is supported. If you've

--- a/custom_jzIntv.mak.template
+++ b/custom_jzIntv.mak.template
@@ -119,6 +119,26 @@ ifeq (,$(TARGET_MAKEFILE))
 endif
 
 # ------------------------------------------------------------------------- #
+# SVN Authentication
+# ------------------------------------------------------------------------- #
+# You may need a svn user name for sync operations. This is more likely
+# if you've got SVN set up for your jzIntv source and Git for VINTage.
+# ------------------------------------------------------------------------- #
+SVN_USERNAME ?= 
+SVN_PASSPHRASE ?= 
+
+# ------------------------------------------------------------------------- #
+# Set up the arguments needed for SVN access.
+# ------------------------------------------------------------------------- #
+SVN_CREDENTIALS := 
+ifneq ($(SVN_USERNAME),)
+  SVN_CREDENTIALS += --username $(SVN_USERNAME)
+endif
+ifneq ($(SVN_PASSPHRASE),)
+  SVN_CREDENTIALS += --password $(SVN_PASSPHRASE)
+endif
+
+# ------------------------------------------------------------------------- #
 # Syncing the jzIntv Sources
 # ------------------------------------------------------------------------- #
 # If you have set up access to a source control system for the jzIntv code


### PR DESCRIPTION
Using SVN (for jzIntv) and Git in the same project at the same time with different credentials for each may require you to keep flip-flopping between credentials. Added support for doing this in the most simplistic way possible for svn - the --username and --password arguments.