### PR TITLE
Fix issues 203 204 ecs and hackfile paths

### DIFF
--- a/INTV.Shared/Utility/PathUtils.Linux.cs
+++ b/INTV.Shared/Utility/PathUtils.Linux.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="PathUtils.Linux.cs" company="INTV Funhouse">
-// Copyright (c) 2017 All Rights Reserved
+// Copyright (c) 2017-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -149,6 +149,17 @@ namespace INTV.Shared.Utility
                     System.Diagnostics.Process.Start(path.AbsoluteUri);
                 }
             }
+        }
+
+        /// <summary>
+        /// Resolves the path for settings.
+        /// </summary>
+        /// <returns>The path for settings.</returns>
+        /// <param name="path">Path.</param>
+        public static string ResolvePathForSettings(string path)
+        {
+            // TODO: Consider supporting Url syntax.
+            return path;
         }
 
         private static string OSFixUpSeparators(string path)

--- a/INTV.Shared/Utility/PathUtils.Linux.cs
+++ b/INTV.Shared/Utility/PathUtils.Linux.cs
@@ -155,7 +155,7 @@ namespace INTV.Shared.Utility
         /// Resolves the path for settings.
         /// </summary>
         /// <returns>The path for settings.</returns>
-        /// <param name="path">Path.</param>
+        /// <param name="path">A path in Uri syntax.</param>
         public static string ResolvePathForSettings(string path)
         {
             // TODO: Consider supporting Url syntax.

--- a/INTV.Shared/Utility/PathUtils.Mac.cs
+++ b/INTV.Shared/Utility/PathUtils.Mac.cs
@@ -154,7 +154,7 @@ namespace INTV.Shared.Utility
         /// Resolves the path for settings.
         /// </summary>
         /// <returns>The path for settings.</returns>
-        /// <param name="path">Path.</param>
+        /// <param name="path">A path in Uri syntax.</param>
         public static string ResolvePathForSettings(string path)
         {
             var url = NSUrl.FromFilename(path);

--- a/INTV.Shared/Utility/PathUtils.Mac.cs
+++ b/INTV.Shared/Utility/PathUtils.Mac.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="PathUtils.Mac.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2017 All Rights Reserved
+// Copyright (c) 2014-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -148,6 +148,18 @@ namespace INTV.Shared.Utility
         public static void RevealInFileSystem(this IEnumerable<string> files)
         {
             NSWorkspace.SharedWorkspace.ActivateFileViewer(files.Select(f => NSUrl.FromFilename(f)).ToArray());
+        }
+
+        /// <summary>
+        /// Resolves the path for settings.
+        /// </summary>
+        /// <returns>The path for settings.</returns>
+        /// <param name="path">Path.</param>
+        public static string ResolvePathForSettings(string path)
+        {
+            var url = NSUrl.FromFilename(path);
+            path = url.AbsoluteString;
+            return path;
         }
 
         private static string OSFixUpSeparators(string path)

--- a/INTV.Shared/Utility/PathUtils.WPF.cs
+++ b/INTV.Shared/Utility/PathUtils.WPF.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="PathUtils.WPF.cs" company="INTV Funhouse">
-// Copyright (c) 2015 All Rights Reserved
+// Copyright (c) 2015-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -148,6 +148,17 @@ namespace INTV.Shared.Utility
                 NativeMethods.ReleaseComObject(directory);
                 NativeMethods.ReleaseComObject(filesToSelectIntPtrs);
             }
+        }
+
+        /// <summary>
+        /// Resolves the path for settings.
+        /// </summary>
+        /// <returns>The path for settings.</returns>
+        /// <param name="path">Path.</param>
+        public static string ResolvePathForSettings(string path)
+        {
+            // TODO: Consider supporting Url syntax.
+            return path;
         }
 
         private static string OSFixUpSeparators(string path)

--- a/INTV.Shared/Utility/PathUtils.WPF.cs
+++ b/INTV.Shared/Utility/PathUtils.WPF.cs
@@ -154,7 +154,7 @@ namespace INTV.Shared.Utility
         /// Resolves the path for settings.
         /// </summary>
         /// <returns>The path for settings.</returns>
-        /// <param name="path">Path.</param>
+        /// <param name="path">A path in Uri syntax.</param>
         public static string ResolvePathForSettings(string path)
         {
             // TODO: Consider supporting Url syntax.

--- a/INTV.jzIntvUI/Commands/ConfigurationCommandGroup.Mac.cs
+++ b/INTV.jzIntvUI/Commands/ConfigurationCommandGroup.Mac.cs
@@ -67,13 +67,6 @@ namespace INTV.JzIntvUI.Commands
             return resolvedPath;
         }
 
-        private static string ResolvePathForSettings(string path)
-        {
-            var url = NSUrl.FromFilename(path);
-            path = url.AbsoluteString;
-            return path;
-        }
-
         #region CommandGroup
 
         /// <summary>

--- a/INTV.jzIntvUI/Commands/ConfigurationCommandGroup.cs
+++ b/INTV.jzIntvUI/Commands/ConfigurationCommandGroup.cs
@@ -481,7 +481,15 @@ namespace INTV.JzIntvUI.Commands
         /// <remarks>The EXEC and GROM ROMs MUST be locatable. The ECS ROM will only be strictly required if so indicated.</remarks>
         internal static bool AreRequiredEmulatorPathsValid(bool includeEcsCheck)
         {
-            return IsEmulatorPathValid() && IsExecRomPathvalid(Properties.Settings.Default.ExecRomPath) && IsGromRomPathValid(Properties.Settings.Default.GromRomPath) && (!includeEcsCheck || IsEcsRomPathValid());
+            var emulatorPathIsValid = IsEmulatorPathValid();
+            var execRomPathIsValid = IsExecRomPathvalid(Properties.Settings.Default.ExecRomPath);
+            var gromPathIsValid = IsGromRomPathValid(Properties.Settings.Default.GromRomPath);
+            var ecsPathIsValid = !includeEcsCheck;
+            if (includeEcsCheck)
+            {
+                ecsPathIsValid = IsEcsRomPathValid();
+            }
+            return emulatorPathIsValid && execRomPathIsValid && gromPathIsValid && ecsPathIsValid;
         }
 
         /// <summary>

--- a/INTV.jzIntvUI/Commands/ConfigurationCommandGroup.cs
+++ b/INTV.jzIntvUI/Commands/ConfigurationCommandGroup.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="ConfigurationCommandGroup.cs" company="INTV Funhouse">
-// Copyright (c) 2016-2017 All Rights Reserved
+// Copyright (c) 2016-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -433,11 +433,12 @@ namespace INTV.JzIntvUI.Commands
         /// <summary>
         /// Determines whether the path to the ECS ROM is valid.
         /// </summary>
+        /// <param name="path">Absolute path to the ECS ROM.</param>
         /// <returns><c>true</c>, if ECS rom path appears to be valid, <c>false</c> otherwise.</returns>
         /// <remarks>This checks only that the file exists, and appears to be a ROM. Note that for .bin format ROMs, that check is not very reliable.</remarks>
-        internal static bool IsEcsRomPathValid()
+        internal static bool IsEcsRomPathValid(string path)
         {
-            var ecsRomPath = ResolvePathSetting(Properties.Settings.Default.EcsRomPath);
+            var ecsRomPath = ResolvePathSetting(path);
             if (string.IsNullOrEmpty(ecsRomPath) && IsEmulatorPathValid())
             {
                 var emulatorPath = SingleInstanceApplication.Instance.GetConfiguration<JzIntvLauncherConfiguration>().EmulatorPath;
@@ -447,12 +448,7 @@ namespace INTV.JzIntvUI.Commands
                     ecsRomPath = System.IO.Path.Combine(emulatorDirectory, "ECS.bin");
                 }
             }
-            var isValid = IsPathValid(ecsRomPath);
-            if (isValid)
-            {
-                // Ensure that this at least appears to be a valid ROM.
-                isValid = Rom.CheckRomFormat(ecsRomPath) == RomFormat.Bin;
-            }
+            var isValid = IsRomPathValid(ecsRomPath);
             return isValid;
         }
 
@@ -487,7 +483,7 @@ namespace INTV.JzIntvUI.Commands
             var ecsPathIsValid = !includeEcsCheck;
             if (includeEcsCheck)
             {
-                ecsPathIsValid = IsEcsRomPathValid();
+                ecsPathIsValid = IsEcsRomPathValid(Properties.Settings.Default.ExecRomPath);
             }
             return emulatorPathIsValid && execRomPathIsValid && gromPathIsValid && ecsPathIsValid;
         }
@@ -518,7 +514,7 @@ namespace INTV.JzIntvUI.Commands
                 {
                     missingFiles.Add("GROM.bin");
                 }
-                if (includeEcsCheck && !IsEcsRomPathValid())
+                if (includeEcsCheck && !IsEcsRomPathValid(Properties.Settings.Default.EcsRomPath))
                 {
                     missingFiles.Add("ECS.bin");
                 }
@@ -578,7 +574,7 @@ namespace INTV.JzIntvUI.Commands
                 var result = browser.ShowDialog();
                 if (result == FileBrowserDialogResult.Ok)
                 {
-                    var path = ResolvePathForSettings(browser.FileNames.First());
+                    var path = PathUtils.ResolvePathForSettings(browser.FileNames.First());
                     switch (whichFile)
                     {
                         case EmulatorFile.JzIntv:

--- a/INTV.jzIntvUI/Commands/JzIntvLauncherCommandGroup.cs
+++ b/INTV.jzIntvUI/Commands/JzIntvLauncherCommandGroup.cs
@@ -148,18 +148,25 @@ namespace INTV.JzIntvUI.Commands
                 options[CommandLineArgument.Custom] = Properties.Settings.Default.CustomCommandLine;
             }
 
-            // EXEC argument
+            // EXEC ROM argument
             if (!customCommandLine && !string.IsNullOrWhiteSpace(Properties.Settings.Default.ExecRomPath) && ConfigurationCommandGroup.IsExecRomPathvalid(Properties.Settings.Default.ExecRomPath))
             {
                 var execPath = ConfigurationCommandGroup.ResolvePathSetting(Properties.Settings.Default.ExecRomPath);
                 options[CommandLineArgument.ExecPath] = execPath;
             }
 
-            // GROM argument
+            // GROM ROM argument
             if (!customCommandLine && !string.IsNullOrWhiteSpace(Properties.Settings.Default.GromRomPath) && ConfigurationCommandGroup.IsGromRomPathValid(Properties.Settings.Default.GromRomPath))
             {
                 var gromPath = ConfigurationCommandGroup.ResolvePathSetting(Properties.Settings.Default.GromRomPath);
                 options[CommandLineArgument.GromPath] = gromPath;
+            }
+
+            // ECS ROM argument
+            if (!customCommandLine && !string.IsNullOrWhiteSpace(Properties.Settings.Default.EcsRomPath) && ConfigurationCommandGroup.IsEcsRomPathValid(Properties.Settings.Default.EcsRomPath))
+            {
+                var ecsPath = ConfigurationCommandGroup.ResolvePathSetting(Properties.Settings.Default.EcsRomPath);
+                options[CommandLineArgument.EcsPath] = ecsPath;
             }
 
             // ECS argument
@@ -191,14 +198,6 @@ namespace INTV.JzIntvUI.Commands
             }
             if (enableEcs || forceSetting)
             {
-                if (enableEcs)
-                {
-                    if (!string.IsNullOrWhiteSpace(Properties.Settings.Default.EcsRomPath) && ConfigurationCommandGroup.IsEcsRomPathValid())
-                    {
-                        var ecsPath = ConfigurationCommandGroup.ResolvePathSetting(Properties.Settings.Default.EcsRomPath);
-                        options[CommandLineArgument.EcsPath] = ecsPath;
-                    }
-                }
                 options[CommandLineArgument.EnableEcs] = enableEcs;
             }
 
@@ -305,10 +304,13 @@ namespace INTV.JzIntvUI.Commands
             }
 
             // Keyboard hackfile argument
-            if (!customCommandLine && ConfigurationCommandGroup.IsPathValid(Properties.Settings.Default.DefaultKeyboardConfigPath))
+            if (!customCommandLine && !string.IsNullOrWhiteSpace(Properties.Settings.Default.DefaultKeyboardConfigPath))
             {
                 var hackfile = ConfigurationCommandGroup.ResolvePathSetting(Properties.Settings.Default.DefaultKeyboardConfigPath);
-                options[CommandLineArgument.KeyboardHackFile] = hackfile;
+                if (ConfigurationCommandGroup.IsPathValid(hackfile))
+                {
+                    options[CommandLineArgument.KeyboardHackFile] = hackfile;
+                }
             }
 
             // Keyboard map argument
@@ -355,15 +357,15 @@ namespace INTV.JzIntvUI.Commands
             // Classic Game Controller configuration arguments
             if (!customCommandLine)
             {
-                if (ConfigurationCommandGroup.IsPathValid(Properties.Settings.Default.ClassicGameController0ConfigPath))
+                var cgcPath = string.IsNullOrWhiteSpace(Properties.Settings.Default.ClassicGameController0ConfigPath) ? string.Empty : ConfigurationCommandGroup.ResolvePathSetting(Properties.Settings.Default.ClassicGameController0ConfigPath);
+                if (ConfigurationCommandGroup.IsPathValid(cgcPath))
                 {
-                    var configfile = ConfigurationCommandGroup.ResolvePathSetting(Properties.Settings.Default.ClassicGameController0ConfigPath);
-                    options[CommandLineArgument.ClassicGameControllerMaster] = configfile;
+                    options[CommandLineArgument.ClassicGameControllerMaster] = cgcPath;
                 }
-                if (ConfigurationCommandGroup.IsPathValid(Properties.Settings.Default.ClassicGameController1ConfigPath))
+                cgcPath = string.IsNullOrWhiteSpace(Properties.Settings.Default.ClassicGameController1ConfigPath) ? string.Empty : ConfigurationCommandGroup.ResolvePathSetting(Properties.Settings.Default.ClassicGameController1ConfigPath);
+                if (ConfigurationCommandGroup.IsPathValid(cgcPath))
                 {
-                    var configfile = ConfigurationCommandGroup.ResolvePathSetting(Properties.Settings.Default.ClassicGameController1ConfigPath);
-                    options[CommandLineArgument.ClassicGameControllerEcs] = configfile;
+                    options[CommandLineArgument.ClassicGameControllerEcs] = cgcPath;
                 }
             }
 

--- a/INTV.jzIntvUI/ViewModel/DisplayModeViewModel.cs
+++ b/INTV.jzIntvUI/ViewModel/DisplayModeViewModel.cs
@@ -27,7 +27,7 @@ namespace INTV.JzIntvUI.ViewModel
     /// <summary>
     /// ViewModel for DisplayMode.
     /// </summary>
-	public class DisplayModeViewModel : OSViewModelBase
+    public class DisplayModeViewModel : OSViewModelBase
     {
         /// <summary>
         /// Initializes a new instance of the type.

--- a/INTV.jzIntvUI/ViewModel/DisplayResolutionViewModel.cs
+++ b/INTV.jzIntvUI/ViewModel/DisplayResolutionViewModel.cs
@@ -27,7 +27,7 @@ namespace INTV.JzIntvUI.ViewModel
     /// <summary>
     /// ViewModel for DisplayResolution.
     /// </summary>
-	public class DisplayResolutionViewModel : OSViewModelBase
+    public class DisplayResolutionViewModel : OSViewModelBase
     {
         /// <summary>
         /// Initializes a new instance of the type.

--- a/INTV.jzIntvUI/ViewModel/JzIntvSettingsPageViewModel.cs
+++ b/INTV.jzIntvUI/ViewModel/JzIntvSettingsPageViewModel.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="JzIntvSettingsPageViewModel.cs" company="INTV Funhouse">
-// Copyright (c) 2016-2017 All Rights Reserved
+// Copyright (c) 2016-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -612,7 +612,7 @@ namespace INTV.JzIntvUI.ViewModel
             {
                 color = INTV.Core.Model.Stic.Color.Red.ToColor();
             }
-            else if (!ConfigurationCommandGroup.IsEcsRomPathValid())
+            else if (!ConfigurationCommandGroup.IsEcsRomPathValid(EcsRomPath))
             {
                 color = INTV.Core.Model.Stic.Color.Orange.ToColor();
             }


### PR DESCRIPTION
Fix #203 - In this case, the problem was that we'd only send the ECS.BIN path if ECS was a required or optional flag on the ROM. When passing a custom command line, you can also require ECS despite whatever the ROM settings say, and this would cause jzintv to error out.  Now, if user configures ECS.BIN, just always send it.

Fix #204 - keyboard hackfile not working.  This was simply a case of passing the Mac's URL path format used from settings rather than the file system path format. Fixed that up.

Along the way, tidy up a couple path manipulation functions across the platforms.