### PR TITLE
Rename ToolsDirectory property

### DIFF
--- a/INTV.LtoFlash/ViewModel/MenuLayoutViewModel.cs
+++ b/INTV.LtoFlash/ViewModel/MenuLayoutViewModel.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="MenuLayoutViewModel.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2017 All Rights Reserved
+// Copyright (c) 2014-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -173,7 +173,7 @@ namespace INTV.LtoFlash.ViewModel
                 _filePath = savedMenuPath;
                 Model = LoadMenuLayout(savedMenuPath);
                 MenuLayout.MenuLayoutSaved += HandleMenuLayoutSaved;
-                var toolsLocation = SingleInstanceApplication.Instance.GetConfiguration<JzIntv.Model.Configuration>().ToolsDirectory;
+                var toolsLocation = SingleInstanceApplication.Instance.GetConfiguration<JzIntv.Model.Configuration>().DefaultToolsDirectory;
                 if (!System.IO.Directory.Exists(toolsLocation))
                 {
                     throw new InvalidOperationException(Resources.Strings.ToolsDirectoryMissingMessage);

--- a/INTV.Shared/Model/IRomHelpers.cs
+++ b/INTV.Shared/Model/IRomHelpers.cs
@@ -214,7 +214,7 @@ namespace INTV.Shared.Model
             if (!string.IsNullOrEmpty(rom.ConfigPath) && (PathComparer.Instance.Compare(Path.GetDirectoryName(rom.RomPath), Path.GetDirectoryName(rom.ConfigPath)) != 0))
             {
                 var jzIntv = INTV.Shared.Utility.SingleInstanceApplication.Instance.GetConfiguration<JzIntv.Model.Configuration>();
-                isStockCfgFilePath = PathComparer.Instance.Compare(Path.GetDirectoryName(rom.ConfigPath), jzIntv.ToolsDirectory) == 0;
+                isStockCfgFilePath = PathComparer.Instance.Compare(Path.GetDirectoryName(rom.ConfigPath), jzIntv.DefaultToolsDirectory) == 0;
             }
             return isStockCfgFilePath;
         }

--- a/INTV.Shared/Model/Program/ProgramCollection.cs
+++ b/INTV.Shared/Model/Program/ProgramCollection.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="ProgramCollection.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2017 All Rights Reserved
+// Copyright (c) 2014-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -318,9 +318,9 @@ namespace INTV.Shared.Model.Program
             // jzIntv component's configuration has not been initialized prior to INTV.Core trying
             // to fetch a stock .cfg file. This access attempts to ensure proper order of operations.
             var jzIntvConfiguration = SingleInstanceApplication.Instance.GetConfiguration<INTV.JzIntv.Model.Configuration>();
-            if (!Directory.Exists(jzIntvConfiguration.ToolsDirectory))
+            if (!Directory.Exists(jzIntvConfiguration.DefaultToolsDirectory))
             {
-                throw new FileNotFoundException(Resources.Strings.ToolsDirectoryMissingMessage, jzIntvConfiguration.ToolsDirectory);
+                throw new FileNotFoundException(Resources.Strings.ToolsDirectoryMissingMessage, jzIntvConfiguration.DefaultToolsDirectory);
             }
             var programs = ProgramCollection.Load(filePath);
             Clear();

--- a/INTV.jzIntv/Model/Configuration.cs
+++ b/INTV.jzIntv/Model/Configuration.cs
@@ -62,8 +62,8 @@ namespace INTV.JzIntv.Model
         {
             _programPaths = new Dictionary<ProgramFile, string>();
             var toolsPath = System.IO.Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, ToolsDirectoryName);
-            ToolsDirectory = toolsPath;
-            IRomHelpers.AddConfigurationEntry(IRomHelpers.ToolsDirectoryKey, ToolsDirectory + System.IO.Path.DirectorySeparatorChar);
+            DefaultToolsDirectory = toolsPath;
+            IRomHelpers.SetConfigurationEntry(IRomHelpers.DefaultToolsDirectoryKey, DefaultToolsDirectory + System.IO.Path.DirectorySeparatorChar);
             ProgramFile[] toolApps =
                 {
                     INTV.JzIntv.Model.ProgramFile.Bin2Rom,
@@ -93,9 +93,9 @@ namespace INTV.JzIntv.Model
         }
 
         /// <summary>
-        /// Gets the directory in which tools are located.
+        /// Gets the directory in which tools are located by default.
         /// </summary>
-        public string ToolsDirectory { get; private set; }
+        public string DefaultToolsDirectory { get; private set; }
 
         /// <summary>
         /// Gets or sets the display mode to use.
@@ -178,7 +178,7 @@ namespace INTV.JzIntv.Model
             if (_programPaths.TryGetValue(program, out programPath))
             {
                 programPath = System.IO.Path.Combine(programPath, program.ProgramName()) + ProgramSuffix;
-                IRomHelpers.AddConfigurationEntry(program.ToString(), programPath); // ensure it's registered w/ INTV.Core
+                IRomHelpers.SetConfigurationEntry(program.ToString(), programPath); // ensure it's registered w/ INTV.Core
             }
             return programPath;
         }


### PR DESCRIPTION
Rename the jzIntv 'ToolsDirectory' location to 'DefaultToolsDirectory' in preparation for making these things more configurable in future updates.