### PR TITLE
Assign default value for SKIP_IF_JZINTV_EMPTY

### DIFF
--- a/custom_jzIntv.mak.template
+++ b/custom_jzIntv.mak.template
@@ -68,6 +68,12 @@ JZINTV_DIR_LINUX =
 JZINTV_DIR       = $(JZINTV_DIR_$(TARGET_OS))
 
 # ------------------------------------------------------------------------- #
+# This value defaults to 1 to skip the local jzIntv build when the path to
+# the jzIntv source is not specified.
+# ------------------------------------------------------------------------- #
+SKIP_IF_JZINTV_EMPTY ?= 1
+
+# ------------------------------------------------------------------------- #
 # Validate configuration for jzIntv.
 # ------------------------------------------------------------------------- #
 ifeq (,$(JZINTV_DIR))


### PR DESCRIPTION
When you create a fresh clone of this repo, we should default the SKIP_IF_JZINTV_EMPTY variable to 1 so builds without the jzintv sources go smoothly.