### PR TITLE
Add IProgramMetadata interface

### DIFF
--- a/INTV.Core/INTV.Core.Mac.csproj
+++ b/INTV.Core/INTV.Core.Mac.csproj
@@ -103,6 +103,8 @@
     <Compile Include="Model\Program\IProgramInformation.cs" />
     <Compile Include="Model\Program\IProgramInformationHelpers.cs" />
     <Compile Include="Model\Program\IProgramInformationTable.cs" />
+    <Compile Include="Model\Program\IProgramMetadata.cs" />
+    <Compile Include="Model\Program\IProgramMetadataHelpers.cs" />
     <Compile Include="Model\Program\IncompatibilityFlags.cs" />
     <Compile Include="Model\Program\IntellicartCC3Features.cs" />
     <Compile Include="Model\Program\IntvFunhouseXmlProgramInformation.cs" />

--- a/INTV.Core/INTV.Core.VSMac.csproj
+++ b/INTV.Core/INTV.Core.VSMac.csproj
@@ -114,6 +114,8 @@
     <Compile Include="Model\Program\IProgramInformation.cs" />
     <Compile Include="Model\Program\IProgramInformationHelpers.cs" />
     <Compile Include="Model\Program\IProgramInformationTable.cs" />
+    <Compile Include="Model\Program\IProgramMetadata.cs" />
+    <Compile Include="Model\Program\IProgramMetadataHelpers.cs" />
     <Compile Include="Model\Program\IncompatibilityFlags.cs" />
     <Compile Include="Model\Program\IntellicartCC3Features.cs" />
     <Compile Include="Model\Program\IntvFunhouseXmlProgramInformation.cs" />

--- a/INTV.Core/INTV.Core.XamMac.csproj
+++ b/INTV.Core/INTV.Core.XamMac.csproj
@@ -112,6 +112,8 @@
     <Compile Include="Model\Program\IProgramInformation.cs" />
     <Compile Include="Model\Program\IProgramInformationHelpers.cs" />
     <Compile Include="Model\Program\IProgramInformationTable.cs" />
+    <Compile Include="Model\Program\IProgramMetadata.cs" />
+    <Compile Include="Model\Program\IProgramMetadataHelpers.cs" />
     <Compile Include="Model\Program\IncompatibilityFlags.cs" />
     <Compile Include="Model\Program\IntellicartCC3Features.cs" />
     <Compile Include="Model\Program\IntvFunhouseXmlProgramInformation.cs" />

--- a/INTV.Core/INTV.Core.pcl.csproj
+++ b/INTV.Core/INTV.Core.pcl.csproj
@@ -109,6 +109,8 @@
     <Compile Include="Model\Program\IProgramDescription.cs" />
     <Compile Include="Model\Program\IProgramInformation.cs" />
     <Compile Include="Model\Program\IProgramInformationTable.cs" />
+    <Compile Include="Model\Program\IProgramMetadata.cs" />
+    <Compile Include="Model\Program\IProgramMetadataHelpers.cs" />
     <Compile Include="Model\Program\JlpFeatures.cs" />
     <Compile Include="Model\Program\KeyboardComponentFeatures.cs" />
     <Compile Include="Model\Program\ProgramDescriptionHelpers.cs" />

--- a/INTV.Core/INTV.Core.xp.csproj
+++ b/INTV.Core/INTV.Core.xp.csproj
@@ -110,6 +110,8 @@
     <Compile Include="Model\Program\IProgramInformation.cs" />
     <Compile Include="Model\Program\IProgramInformationHelpers.cs" />
     <Compile Include="Model\Program\IProgramInformationTable.cs" />
+    <Compile Include="Model\Program\IProgramMetadata.cs" />
+    <Compile Include="Model\Program\IProgramMetadataHelpers.cs" />
     <Compile Include="Model\Program\JlpFeatures.cs" />
     <Compile Include="Model\Program\KeyboardComponentFeatures.cs" />
     <Compile Include="Model\Program\LtoFlashFeatures.cs" />

--- a/INTV.Core/Model/Program/CfgFileMetadataProgramInformation.cs
+++ b/INTV.Core/Model/Program/CfgFileMetadataProgramInformation.cs
@@ -17,8 +17,7 @@
 // or write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 // </copyright>
-    
-using System;
+
 using System.Collections.Generic;
 using System.Linq;
 
@@ -29,12 +28,6 @@ namespace INTV.Core.Model.Program
     /// </summary>
     public class CfgFileMetadataProgramInformation : ProgramInformation
     {
-        private string _title;
-        private string _vendor;
-        private string _year;
-        private CrcData _crc;
-        private ProgramFeatures _features;
-
         #region Constructors
 
         public CfgFileMetadataProgramInformation(IRom rom)
@@ -150,6 +143,7 @@ namespace INTV.Core.Model.Program
             get { return _title; }
             set { _title = value; }
         }
+        private string _title;
 
         /// <inheritdoc />
         public override string Vendor
@@ -157,6 +151,7 @@ namespace INTV.Core.Model.Program
             get { return _vendor; }
             set { _vendor = value; }
         }
+        private string _vendor;
 
         /// <inheritdoc />
         public override string Year
@@ -164,6 +159,7 @@ namespace INTV.Core.Model.Program
             get { return _year; }
             set { _year = value; }
         }
+        private string _year;
 
         /// <inheritdoc />
         public override ProgramFeatures Features
@@ -171,134 +167,128 @@ namespace INTV.Core.Model.Program
             get { return _features; }
             set { _features = value; }
         }
+        private ProgramFeatures _features;
 
         /// <inheritdoc />
         public override IEnumerable<CrcData> Crcs
         {
             get { yield return _crc; }
         }
+        private CrcData _crc;
 
         #endregion IProgramInformation
 
-        /// <summary>
-        /// Gets the authors.
-        /// </summary>
-        public IEnumerable<string> Authors
+        #region IProgramMetadata
+
+        /// <inheritdoc />
+        public override IEnumerable<string> LongNames
         {
-            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.Author).Select(m => m.StringValue); }
+            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.Name).Select(m => m.StringValue); }
         }
 
-        /// <summary>
-        /// Gets the graphics artists.
-        /// </summary>
-        public IEnumerable<string> Graphics
+        /// <inheritdoc />
+        public override IEnumerable<string> ShortNames
         {
-            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.GameArt).Select(m => m.StringValue); }
+            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.ShortName).Select(m => m.StringValue); }
         }
 
-        /// <summary>
-        /// Gets the music credits.
-        /// </summary>
-        public IEnumerable<string> Music
-        {
-            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.Music).Select(m => m.StringValue); }
-        }
-
-        /// <summary>
-        /// Gets the sound effects credits.
-        /// </summary>
-        public IEnumerable<string> SoundEffects
-        {
-            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.SoundEffects).Select(m => m.StringValue); }
-        }
-
-        /// <summary>
-        /// Gets the voice acting credits.
-        /// </summary>
-        public IEnumerable<string> Voices
-        {
-            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.VoiceActing).Select(m => m.StringValue); }
-        }
-
-        /// <summary>
-        /// Gets the documentation credits.
-        /// </summary>
-        public IEnumerable<string> Documentation
-        {
-            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.Documentation).Select(m => m.StringValue); }
-        }
-
-        /// <summary>
-        /// Gets the artwork credits for boxes, et. al.
-        /// </summary>
-        public IEnumerable<string> Artwork
-        {
-            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.BoxOrOtherArtwork).Select(m => m.StringValue); }
-        }
-
-        /// <summary>
-        /// Gets the program concept credits.
-        /// </summary>
-        public IEnumerable<string> Concept
-        {
-            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.ConceptDesign).Select(m => m.StringValue); }
-        }
-
-        /// <summary>
-        /// Gets the 'more info' values.
-        /// </summary>
-        public IEnumerable<string> MoreInfo
-        {
-            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.MoreInfo).Select(m => m.StringValue); }
-        }
-
-        /// <summary>
-        /// Gets the publishers.
-        /// </summary>
-        public IEnumerable<string> Publishers
-        {
-            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.Publisher).Select(m => m.StringValue); }
-        }
-
-        /// <summary>
-        /// Gets the release licenses.
-        /// </summary>
-        public IEnumerable<string> Licenses
-        {
-            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.License).Select(m => m.StringValue); }
-        }
-
-        /// <summary>
-        /// Gets the descriptions.
-        /// </summary>
-        public IEnumerable<string> Descriptions
+        /// <inheritdoc />
+        public override IEnumerable<string> Descriptions
         {
             get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.Description).Select(m => m.StringValue); }
         }
 
-        /// <summary>
-        /// Gets the release dates.
-        /// </summary>
-        public IEnumerable<MetadataDateTime> ReleaseDates
+        /// <inheritdoc />
+        public override IEnumerable<string> Publishers
+        {
+            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.Publisher).Select(m => m.StringValue); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Programmers
+        {
+            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.Author).Select(m => m.StringValue); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Designers
+        {
+            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.ConceptDesign).Select(m => m.StringValue); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Graphics
+        {
+            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.GameArt).Select(m => m.StringValue); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Music
+        {
+            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.Music).Select(m => m.StringValue); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> SoundEffects
+        {
+            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.SoundEffects).Select(m => m.StringValue); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Voices
+        {
+            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.VoiceActing).Select(m => m.StringValue); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Documentation
+        {
+            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.Documentation).Select(m => m.StringValue); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Artwork
+        {
+            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.BoxOrOtherArtwork).Select(m => m.StringValue); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<MetadataDateTime> ReleaseDates
         {
             get { return Metadata.OfType<CfgVarMetadataDate>().Where(m => m.Type == CfgVarMetadataIdTag.ReleaseDate).Select(m => m.Date); }
         }
 
-        /// <summary>
-        /// Gets the build dates.
-        /// </summary>
-        public IEnumerable<MetadataDateTime> BuildDates
+        /// <inheritdoc />
+        public override IEnumerable<string> Licenses
+        {
+            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.License).Select(m => m.StringValue); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> ContactInformation
+        {
+            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.MoreInfo).Select(m => m.StringValue); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Versions
+        {
+            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.Version).Select(m => m.StringValue); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<MetadataDateTime> BuildDates
         {
             get { return Metadata.OfType<CfgVarMetadataDate>().Where(m => m.Type == CfgVarMetadataIdTag.BuildDate).Select(m => m.Date); }
         }
 
-        /// <summary>
-        /// Gets the versions.
-        /// </summary>
-        public IEnumerable<string> Versions
+        /// <inheritdoc />
+        public override IEnumerable<string> AdditionalInformation
         {
-            get { return Metadata.OfType<CfgVarMetadataString>().Where(m => m.Type == CfgVarMetadataIdTag.Version).Select(m => m.StringValue); }
+            get { yield break; }
         }
+
+        #endregion // IProgramMetadata
 
         /// <summary>
         /// Gets all the metadata in its originally parsed form.

--- a/INTV.Core/Model/Program/IProgramMetadata.cs
+++ b/INTV.Core/Model/Program/IProgramMetadata.cs
@@ -1,0 +1,123 @@
+﻿// <copyright file="IProgramMetadata.cs" company="INTV Funhouse">
+// Copyright (c) 2018 All Rights Reserved
+// <author>Steven A. Orth</author>
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this software. If not, see: http://www.gnu.org/licenses/.
+// or write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+// </copyright>
+
+using System.Collections.Generic;
+
+namespace INTV.Core.Model.Program
+{
+    /// <summary>
+    /// This interface describes metadata that a program may provide. These fields are supported across
+    /// the various known Intellivision ROM formats to varying degrees.
+    /// </summary>
+    public interface IProgramMetadata
+    {
+        /// <summary>
+        /// Gets the long names for the program.
+        /// </summary>
+        /// <remarks>A practical limit to this is sixty (60) characters.</remarks>
+        IEnumerable<string> LongNames { get; }
+
+        /// <summary>
+        /// Gets the short names for the program.
+        /// </summary>
+        /// <remarks>A practical limit to this is eighteen (18) characters.</remarks>
+        IEnumerable<string> ShortNames { get; }
+
+        /// <summary>
+        /// Gets the descriptions of the program.
+        /// </summary>
+        IEnumerable<string> Descriptions { get; }
+
+        /// <summary>
+        /// Gets the publishers of the program.
+        /// </summary>
+        IEnumerable<string> Publishers { get; }
+
+        /// <summary>
+        /// Gets the developers who contributed code to the program.
+        /// </summary>
+        IEnumerable<string> Programmers { get; }
+
+        /// <summary>
+        /// Gets the program concept creators / designers.
+        /// </summary>
+        IEnumerable<string> Designers { get; }
+
+        /// <summary>
+        /// Gets the pixel artists.
+        /// </summary>
+        IEnumerable<string> Graphics { get; }
+
+        /// <summary>
+        /// Gets the music composers / arrangers.
+        /// </summary>
+        IEnumerable<string> Music { get; }
+
+        /// <summary>
+        /// Gets the sound effects designers / creators.
+        /// </summary>
+        IEnumerable<string> SoundEffects { get; }
+
+        /// <summary>
+        /// Gets the voice actors.
+        /// </summary>
+        IEnumerable<string> Voices { get; }
+
+        /// <summary>
+        /// Gets the program documentation authors.
+        /// </summary>
+        IEnumerable<string> Documentation { get; }
+
+        /// <summary>
+        /// Gets the program box art and other non-in-application artwork.
+        /// </summary>
+        IEnumerable<string> Artwork { get; }
+
+        /// <summary>
+        /// Gets the release dates of the program.
+        /// </summary>
+        IEnumerable<MetadataDateTime> ReleaseDates { get; }
+
+        /// <summary>
+        /// Gets the licenses under which the program and possibly its source code are released.
+        /// </summary>
+        IEnumerable<string> Licenses { get; }
+
+        /// <summary>
+        /// Gets the contact or other information regarding the program.
+        /// </summary>
+        IEnumerable<string> ContactInformation { get; }
+
+        /// <summary>
+        /// Gets the short version descriptions, e.g. 1.0.1 or alpha 0, et. al.
+        /// </summary>
+        IEnumerable<string> Versions { get; }
+
+        /// <summary>
+        /// Gets the build dates for the program.
+        /// </summary>
+        IEnumerable<MetadataDateTime> BuildDates { get; }
+
+        /// <summary>
+        /// Gets other miscellaneous additional information.
+        /// </summary>
+        IEnumerable<string> AdditionalInformation { get; }
+    }
+}

--- a/INTV.Core/Model/Program/IProgramMetadataHelpers.cs
+++ b/INTV.Core/Model/Program/IProgramMetadataHelpers.cs
@@ -1,0 +1,29 @@
+﻿// <copyright file="IProgramMetadataHelpers.cs" company="INTV Funhouse">
+// Copyright (c) 2018 All Rights Reserved
+// <author>Steven A. Orth</author>
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this software. If not, see: http://www.gnu.org/licenses/.
+// or write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+// </copyright>
+
+namespace INTV.Core.Model.Program
+{
+    /// <summary>
+    /// Extension methods to help when working with <see cref="IProgramMetadata"/>.
+    /// </summary>
+    public static class IProgramMetadataHelpers
+    {
+    }
+}

--- a/INTV.Core/Model/Program/IntvFunhouseXmlProgramInformation.cs
+++ b/INTV.Core/Model/Program/IntvFunhouseXmlProgramInformation.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="IntvFunhouseXmlProgramInformation.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2015 All Rights Reserved
+// Copyright (c) 2014-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -20,7 +20,9 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using INTV.Core.Model;
 using INTV.Core.Model.Program;
+using INTV.Core.Utility;
 
 namespace INTV.Core.Restricted.Model.Program
 {
@@ -43,33 +45,37 @@ namespace INTV.Core.Restricted.Model.Program
         /// </summary>
         public const int MaxVendorNameLength = 32;
 
-        private string _code;
-        private string _title;
-        private string _vendor;
-        private string _orig_vendor;
-        private string _year;
-        private int _ntsc;
-        private int _pal;
-        private int _generalFeatures;
-        private int _keyboardComponent;
-        private int _sva;
-        private int _intellivoice;
-        private int _intyii;
-        private int _ecs;
-        private int _tutorvision;
-        private int _icart;
-        private int _cc3;
-        private int _jlp;
-        private string _jlp_savedata;
-        private int _ltoFlash;
-        private int _bee3;
-        private int _hive;
-        private string _crcString;
-        private string _crcNotesString;
-        private string _crcIncompatibilitiesString;
-        private List<CrcData> _crc = new List<CrcData>();
-        private ProgramFeatures _features;
-        private string _externalInfo;
+        /// <summary>
+        /// Basic vendor information.
+        /// </summary>
+        /// <remarks>NOTE: This information is manually copied from the INTV Funhouse vendors database. In some cases, it may have diverged.</remarks>
+        private static readonly Dictionary<string, VendorUrls> VendorInfo = new Dictionary<string, VendorUrls>(System.StringComparer.OrdinalIgnoreCase)
+            {
+                { "Activision", new VendorUrls("http://intellivisionlives.com/bluesky/games/credits/activision.shtml", "http://intellivisionlives.com/bluesky/games/") },
+                { "Atarisoft", new VendorUrls("http://intellivisionlives.com/bluesky/games/credits/atarisoft.shtml", "http://intellivisionlives.com/bluesky/games/") },
+                { "Coleco", new VendorUrls("http://intellivisionlives.com/bluesky/games/credits/colecoint.shtml", "http://intellivisionlives.com/bluesky/games/") },
+                { "Dextell Ltd.", new VendorUrls(null, "http://intellivisionlives.com/bluesky/games/") },
+                { "Imagic", new VendorUrls("http://intellivisionlives.com/bluesky/games/credits/imagic.shtml", "http://intellivisionlives.com/bluesky/games/") },
+                { "Intellivision Inc.", new VendorUrls(null, "http://intellivisionlives.com/bluesky/games/") },
+                { "CollectorVision", new VendorUrls("http://collectorvision.com/", "https://collectorvision.com/shop/intellivision") },
+                { "Interphase", new VendorUrls("http://intellivisionlives.com/bluesky/games/credits/interphase.shtml", "http://intellivisionlives.com/bluesky/games/") },
+                { "INTV Corporation", new VendorUrls("http://intellivisionlives.com/bluesky/games/credits/intv.shtml", "http://intellivisionlives.com/bluesky/games/") },
+                { "Mattel Electronics", new VendorUrls("http://intellivisionlives.com/bluesky/games/", "http://intellivisionlives.com/bluesky/games/") },
+                { "Parker Brothers", new VendorUrls("http://intellivisionlives.com/bluesky/games/credits/parkerbros.shtml", "http://intellivisionlives.com/bluesky/games/") },
+                { "Sears", new VendorUrls(null, "http://intellivisionlives.com/bluesky/games/") },
+                { "Sega", new VendorUrls("http://intellivisionlives.com/bluesky/games/credits/sega.shtml", "http://intellivisionlives.com/bluesky/games/") },
+                { "Elektronite", new VendorUrls("http://elektronite.net", "http://elektronite.net/gallery") },
+                { "Left Turn Only", new VendorUrls("http://www.leftturnonly.info/") },
+                { "Intelligentvision", new VendorUrls("http://intellivision.us", "http://intellivision.us/intvgames") },
+                { "INTV Funhouse", new VendorUrls("http://www.intvfunhouse.com/", "http://www.intvfunhouse.com/intvfunhouse.com/games/") },
+                { "Intellivision Revolution", new VendorUrls("http://www.intellivisionrevolution.com/") },
+                { "Blah Blah Woof Woof", new VendorUrls("http://www.blahblahwoofwoof.com/") },
+                { "Homebrew, Inc.", new VendorUrls("http://fwgames.ca/", "http://fwgames.ca/") },
+                { "2600 Connection", new VendorUrls("http://www.2600connection.com/") },
+                { "Team Pixelboy", new VendorUrls("http://teampixelboy.com/", "http://teampixelboy.com/") },
+            };
+
+        #region Properties
 
         #region XML-Populated Properties
 
@@ -85,6 +91,7 @@ namespace INTV.Core.Restricted.Model.Program
             get { return _ntsc; }
             set { _ntsc = (int)((FeatureCompatibility)value).CoerceVideoStandardCompatibility(); }
         }
+        private int _ntsc;
 
         /// <summary>
         /// Gets or sets the PAL compatibility bits.
@@ -95,146 +102,91 @@ namespace INTV.Core.Restricted.Model.Program
             get { return _pal; }
             set { _pal = (int)((FeatureCompatibility)value).CoerceVideoStandardCompatibility(); }
         }
+        private int _pal;
 
         /// <summary>
         /// Gets or sets the general ROM features.
         /// </summary>
         [System.Xml.Serialization.XmlElement("general_features")]
-        public int GeneralFeatures
-        {
-            get { return _generalFeatures; }
-            set { _generalFeatures = value; }
-        }
+        public int GeneralFeatures { get; set; }
 
         /// <summary>
         /// Gets or sets the Model 1149 Keyboard Component feature bits.
         /// </summary>
         [System.Xml.Serialization.XmlElement("kc")]
-        public int KeyboardComponentFeatures
-        {
-            get { return _keyboardComponent; }
-            set { _keyboardComponent = value; }
-        }
+        public int KeyboardComponentFeatures { get; set; }
 
         /// <summary>
         /// Gets or sets the Super Video Arcade compatibility bits.
         /// </summary>
         [System.Xml.Serialization.XmlElement("sva")]
-        public int SuperVideoArcadeCompatibility
-        {
-            get { return _sva; }
-            set { _sva = value; }
-        }
+        public int SuperVideoArcadeCompatibility { get; set; }
 
         /// <summary>
         /// Gets or sets the Intellivoice compatibility bits.
         /// </summary>
         [System.Xml.Serialization.XmlElement("ivoice")]
-        public int IntellivoiceCompatibility
-        {
-            get { return _intellivoice; }
-            set { _intellivoice = value; }
-        }
+        public int IntellivoiceCompatibility { get; set; }
 
         /// <summary>
         /// Gets or sets the Intellivision II compatibility bits.
         /// </summary>
         [System.Xml.Serialization.XmlElement("intyii")]
-        public int IntellivisionIICompatibility
-        {
-            get { return _intyii; }
-            set { _intyii = value; }
-        }
+        public int IntellivisionIICompatibility { get; set; }
 
         /// <summary>
         /// Gets or sets the ECS feature bits.
         /// </summary>
         [System.Xml.Serialization.XmlElement("ecs")]
-        public int EcsFeatures
-        {
-            get { return _ecs; }
-            set { _ecs = value; }
-        }
+        public int EcsFeatures { get; set; }
 
         /// <summary>
         /// Gets or sets the Tutorvision compatibility bits.
         /// </summary>
         [System.Xml.Serialization.XmlElement("tutor")]
-        public int TutorVision
-        {
-            get { return _tutorvision; }
-            set { _tutorvision = value; }
-        }
+        public int TutorVision { get; set; }
 
         /// <summary>
         /// Gets or sets the Intellicart feature bits.
         /// </summary>
         [System.Xml.Serialization.XmlElement("icart")]
-        public int IntellicartFeatures
-        {
-            get { return _icart; }
-            set { _icart = value; }
-        }
+        public int IntellicartFeatures { get; set; }
 
         /// <summary>
         /// Gets or sets the Cuttle Cart 3 feature bits.
         /// </summary>
         [System.Xml.Serialization.XmlElement("cc3")]
-        public int CuttleCart3Features
-        {
-            get { return _cc3; }
-            set { _cc3 = value; }
-        }
+        public int CuttleCart3Features { get; set; }
 
         /// <summary>
         /// Gets or sets the JLP feature bits.
         /// </summary>
         [System.Xml.Serialization.XmlElement("jlp")]
-        public int JLPFeatures
-        {
-            get { return _jlp; }
-            set { _jlp = value; }
-        }
+        public int JLPFeatures { get; set; }
 
         /// <summary>
         /// Gets or sets a default name for JLP saved data files. Is this irrelevant?
         /// </summary>
         [System.Xml.Serialization.XmlElement("jlp_savegame")]
-        public string JLPSaveData
-        {
-            get { return _jlp_savedata; }
-            set { _jlp_savedata = value; }
-        }
+        public string JLPSaveData { get; set; }
 
         /// <summary>
         /// Gets or sets the LTO Flash! feature bits.
         /// </summary>
         [System.Xml.Serialization.XmlElement("lto_flash")]
-        public int LtoFlashFeatures
-        {
-            get { return _ltoFlash; }
-            set { _ltoFlash = value; }
-        }
+        public int LtoFlashFeatures { get; set; }
 
         /// <summary>
         /// Gets or sets the Bee3 feature bits.
         /// </summary>
         [System.Xml.Serialization.XmlElement("bee3")]
-        public int Bee3Features
-        {
-            get { return _bee3; }
-            set { _bee3 = value; }
-        }
+        public int Bee3Features { get; set; }
 
         /// <summary>
         /// Gets or sets the Hive multicart feature bits.
         /// </summary>
         [System.Xml.Serialization.XmlElement("hive")]
-        public int HiveFeatures
-        {
-            get { return _hive; }
-            set { _hive = value; }
-        }
+        public int HiveFeatures { get; set; }
 
         #endregion // Features
 
@@ -242,11 +194,7 @@ namespace INTV.Core.Restricted.Model.Program
         /// Gets or sets the INTV Funhouse program code.
         /// </summary>
         [System.Xml.Serialization.XmlElement("code")]
-        public string Code
-        {
-            get { return _code; }
-            set { _code = value; }
-        }
+        public string Code { get; set; }
 
         /// <summary>
         /// Gets or sets the program title.
@@ -255,68 +203,45 @@ namespace INTV.Core.Restricted.Model.Program
         public string ProgramTitle
         {
             get { return _title; }
-            set { _title = value; }
+            set { _title = value.DecodeHtmlString(); }
         }
+        private string _title;
 
         /// <summary>
         /// Gets or sets the game publisher / vendor.
         /// </summary>
         [System.Xml.Serialization.XmlElement("vendor")]
-        public string ProgramVendor
-        {
-            get { return _vendor; }
-            set { _vendor = value; }
-        }
+        public string ProgramVendor { get; set; }
 
         /// <summary>
         /// Gets or sets the game's original publisher / vendor.
         /// </summary>
         [System.Xml.Serialization.XmlElement("orig_vendor")]
-        public string OriginalProgramVendor
-        {
-            get { return _orig_vendor; }
-            set { _orig_vendor = value; }
-        }
+        public string OriginalProgramVendor { get; set; }
 
         /// <summary>
         /// Gets or sets the copyright year of the game.
         /// </summary>
         [System.Xml.Serialization.XmlElement("year")]
-        public string YearString
-        {
-            get { return _year; }
-            set { _year = value; }
-        }
+        public string YearString { get; set; }
 
         /// <summary>
         /// Gets or sets the ROM CRC string from the database.
         /// </summary>
         [System.Xml.Serialization.XmlElement("crc")]
-        public string CrcString
-        {
-            get { return _crcString; }
-            set { _crcString = value; }
-        }
+        public string CrcString { get; set; }
 
         /// <summary>
         /// Gets or sets the CRC notes string from the database.
         /// </summary>
         [System.Xml.Serialization.XmlElement("crc_notes")]
-        public string CrcNotesString
-        {
-            get { return _crcNotesString; }
-            set { _crcNotesString = value; }
-        }
+        public string CrcNotesString { get; set; }
 
         /// <summary>
         /// Gets or sets the CRC incompatibility information from the database.
         /// </summary>
         [System.Xml.Serialization.XmlElement("crc_incompatibilities")]
-        public string CrcIncompatibilitiesString
-        {
-            get { return _crcIncompatibilitiesString; }
-            set { _crcIncompatibilitiesString = value; }
-        }
+        public string CrcIncompatibilitiesString { get; set; }
 
         /// <summary>
         /// Gets or sets the configuration files to use per ROM CRC.
@@ -330,20 +255,81 @@ namespace INTV.Core.Restricted.Model.Program
         private string _binCfgs;
 
         /// <summary>
-        /// Gets or sets the external info (partial) URL for a program.
+        /// Gets or sets the external information (partial) URL for a program.
         /// </summary>
         [System.Xml.Serialization.XmlElement("externalinfo")]
-        public string ExternalInfo
-        {
-            get { return _externalInfo; }
-            set { _externalInfo = value; }
-        }
+        public string ExternalInfo { get; set; }
+
+        /// <summary>
+        /// Gets or sets the release date of the program. Expected to be in standard format YYYY-MM-DD or whatever else is supported by the standard parser.
+        /// </summary>
+        /// <remarks>NOTE: The value 0000-00-00 will throw!</remarks>
+        [System.Xml.Serialization.XmlElement("release_date")]
+        public System.DateTime ReleaseDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the description of the program. This is often from a game catalog.
+        /// </summary>
+        [System.Xml.Serialization.XmlElement("description")]
+        public string ProgramDescription { get; set; }
+
+        /// <summary>
+        /// Gets or sets raw information regarding the developers (programmers) of the program. String is vertical-bar-delimited (|).
+        /// </summary>
+        [System.Xml.Serialization.XmlElement("program")]
+        public string ProgramDevelopers { get; set; }
+
+        /// <summary>
+        /// Gets or sets raw information regarding the concept (design) of the program. String is vertical-bar-delimited (|).
+        /// </summary>
+        [System.Xml.Serialization.XmlElement("concept")]
+        public string ProgramConcept { get; set; }
+
+        /// <summary>
+        /// Gets or sets raw information regarding graphics in the program. String is vertical-bar-delimited (|).
+        /// </summary>
+        [System.Xml.Serialization.XmlElement("game_graphics")]
+        public string ProgramGraphics { get; set; }
+
+        /// <summary>
+        /// Gets or sets raw information regarding sound effects used in the program. String is vertical-bar-delimited (|).
+        /// </summary>
+        [System.Xml.Serialization.XmlElement("soundfx")]
+        public string ProgramSoundEffects { get; set; }
+
+        /// <summary>
+        /// Gets or sets raw information regarding music used in the program. String is vertical-bar-delimited (|).
+        /// </summary>
+        [System.Xml.Serialization.XmlElement("music")]
+        public string ProgramMusic { get; set; }
+
+        /// <summary>
+        /// Gets or sets raw information regarding voice talent used in the program. String is vertical-bar-delimited (|).
+        /// </summary>
+        [System.Xml.Serialization.XmlElement("voices")]
+        public string ProgramVoices { get; set; }
+
+        /// <summary>
+        /// Gets or sets raw information regarding program documentation. String is vertical-bar-delimited (|).
+        /// </summary>
+        [System.Xml.Serialization.XmlElement("game_docs")]
+        public string ProgramDocumentation { get; set; }
+
+        /// <summary>
+        /// Gets or sets information regarding program packaging artwork. String is vertical-bar-delimited (|).
+        /// </summary>
+        [System.Xml.Serialization.XmlElement("box_art")]
+        public string BoxArt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the additional information for a program. String is new-line-delimited.
+        /// </summary>
+        [System.Xml.Serialization.XmlElement("other")]
+        public string OtherInfo { get; set; }
 
         #endregion // XML-Populated Properties
 
         #region IProgramInformation
-
-        #region Properties
 
         /// <inheritdoc />
         public override ProgramInformationOrigin DataOrigin
@@ -381,14 +367,14 @@ namespace INTV.Core.Restricted.Model.Program
         {
             get
             {
-                string yearString = _year.Trim();
-                var copyrightParts = _year.Split(' ');
+                string yearString = YearString.Trim();
+                var copyrightParts = YearString.Split(' ');
                 if (copyrightParts.Length >= 1)
                 {
                     yearString = copyrightParts[0].Trim();
                 }
                 int year;
-                if (int.TryParse(_year, out year))
+                if (int.TryParse(YearString, out year))
                 {
                     yearString = year.ToString();
                 }
@@ -397,7 +383,7 @@ namespace INTV.Core.Restricted.Model.Program
 
             set
             {
-                _year = value;
+                YearString = value;
             }
         }
 
@@ -433,6 +419,7 @@ namespace INTV.Core.Restricted.Model.Program
                 _features = value;
             }
         }
+        private ProgramFeatures _features;
 
         /// <inheritdoc />
         public override IEnumerable<CrcData> Crcs
@@ -468,8 +455,132 @@ namespace INTV.Core.Restricted.Model.Program
                 return _crc;
             }
         }
+        private List<CrcData> _crc = new List<CrcData>();
+
+        #endregion // IProgramInformation
+
+        #region IProgramMetadata
+
+        /// <inheritdoc />
+        public override IEnumerable<string> LongNames
+        {
+            get { yield return Title; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> ShortNames
+        {
+            get { yield return Title.EnforceNameLength(RomInfoIndexHelpers.MaxShortNameLength, restrictToGromCharacters: false); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Descriptions
+        {
+            get { yield return ProgramDescription; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Publishers
+        {
+            get
+            {
+                yield return ProgramVendor;
+                if (!string.IsNullOrEmpty(OriginalProgramVendor))
+                {
+                    yield return OriginalProgramVendor;
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Programmers
+        {
+            get { return SplitMultipleEntryString(ProgramDevelopers, removeEmptyEntries: true, separator: "|"); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Designers
+        {
+            get { return SplitMultipleEntryString(ProgramConcept, removeEmptyEntries: true, separator: "|"); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Graphics
+        {
+            get { return SplitMultipleEntryString(ProgramGraphics, removeEmptyEntries: true, separator: "|"); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Music
+        {
+            get { return SplitMultipleEntryString(ProgramMusic, removeEmptyEntries: true, separator: "|"); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> SoundEffects
+        {
+            get { return SplitMultipleEntryString(ProgramSoundEffects, removeEmptyEntries: true, separator: "|"); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Voices
+        {
+            get { return SplitMultipleEntryString(ProgramVoices, removeEmptyEntries: true, separator: "|"); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Documentation
+        {
+            get { return SplitMultipleEntryString(ProgramDocumentation, removeEmptyEntries: true, separator: "|"); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Artwork
+        {
+            get { return SplitMultipleEntryString(BoxArt, removeEmptyEntries: true, separator: "|"); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<MetadataDateTime> ReleaseDates
+        {
+            get { yield return new MetadataDateTime(new System.DateTimeOffset(ReleaseDate), MetadataDateTimeFlags.Year | MetadataDateTimeFlags.Month | MetadataDateTimeFlags.Day); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Licenses
+        {
+            get { yield break; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> ContactInformation
+        {
+            get { return GetContactInformation(ProgramVendor, OriginalProgramVendor, ExternalInfo); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Versions
+        {
+            get { yield break; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<MetadataDateTime> BuildDates
+        {
+            get { yield break; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> AdditionalInformation
+        {
+            get { return SplitMultipleEntryString(OtherInfo, removeEmptyEntries: true); }
+        }
+
+        #endregion // IProgramMetadata
 
         #endregion // Properties
+
+        #region IProgramInformation
 
         /// <inheritdoc />
         public override bool AddCrc(uint newCrc, string crcDescription, IncompatibilityFlags incompatibilities)
@@ -483,6 +594,115 @@ namespace INTV.Core.Restricted.Model.Program
         public override string ToString()
         {
             return Title;
+        }
+
+        private static IEnumerable<string> GetContactInformation(string programVendor, string originalProgramVendor, string externalInfo)
+        {
+            var contactInformation = new List<string>();
+            var externalInfoUrls = SplitMultipleEntryString(externalInfo, removeEmptyEntries: false);
+            var useOriginalProgramVendorBaseUrl = true;
+            foreach (var externalInfoUrl in externalInfoUrls)
+            {
+                if (!string.IsNullOrEmpty(externalInfoUrl))
+                {
+                    // EXTREMELY simplistic checking here. We're not going the full Uri inspection route.
+                    if (externalInfoUrl.StartsWith("http"))
+                    {
+                        contactInformation.Add(externalInfoUrl);
+                    }
+                    else
+                    {
+                        var vendorBaseUrl = GetContactInfoBaseUrl(programVendor, originalProgramVendor, useOriginalProgramVendorBaseUrl);
+                        if (!string.IsNullOrEmpty(vendorBaseUrl))
+                        {
+                            var contactInfoUrl = vendorBaseUrl;
+                            var needsSlash = !vendorBaseUrl.EndsWith("/") && !externalInfoUrl.StartsWith("/");
+                            if (needsSlash)
+                            {
+                                contactInfoUrl += "/";
+                            }
+                            contactInfoUrl += externalInfoUrl;
+                            contactInformation.Add(contactInfoUrl);
+                        }
+                    }
+                }
+                useOriginalProgramVendorBaseUrl = false;
+            }
+            return contactInformation;
+        }
+
+        private static string GetContactInfoBaseUrl(string programVendor, string originalProgramVendor, bool useOriginalProgramVendor)
+        {
+            var vendor = useOriginalProgramVendor && !string.IsNullOrEmpty(originalProgramVendor) ? originalProgramVendor : programVendor;
+            string contactUrlBase = null;
+            VendorUrls urls;
+            if (!string.IsNullOrEmpty(vendor) && VendorInfo.TryGetValue(vendor, out urls))
+            {
+                contactUrlBase = urls.GameInfoBaseUrl;
+            }
+            return contactUrlBase;
+        }
+
+        /// <summary>
+        /// Splits the given string into multiple entries.
+        /// </summary>
+        /// <param name="rawData">The raw string value to split.</param>
+        /// <param name="removeEmptyEntries">If <c>true</c>, exclude empty strings from the returned values.</param>
+        /// <param name="separator">Specifies separators to use when splitting the string. If none are specified, newline (and combinations of it and carriage return) are used.</param>
+        /// <returns>An enumerable of the values in <paramref name="rawData"/>, which are also HTML decoded, with HTML tags stripped.</returns>
+        private static IEnumerable<string> SplitMultipleEntryString(string rawData, bool removeEmptyEntries, params string[] separator)
+        {
+            var values = Enumerable.Empty<string>();
+            if (!string.IsNullOrEmpty(rawData))
+            {
+                if ((separator == null) || !separator.Any())
+                {
+                    separator  = new[] { "\n", "\r", "\r\n", "\n\r" };
+                }
+                values = rawData.Split(separator, removeEmptyEntries ? System.StringSplitOptions.RemoveEmptyEntries : System.StringSplitOptions.None).Select(s => s.DecodeHtmlString().Trim());
+            }
+            return values;
+        }
+
+        /// <summary>
+        /// Helper class for vendor URL information.
+        /// </summary>
+        private class VendorUrls : System.Tuple<string, string>
+        {
+            /// <summary>
+            /// Initializes an instance of <see cref="VendorUrls"/>.
+            /// </summary>
+            /// <param name="websiteUrl">URL to a vendor's main web page.</param>
+            internal VendorUrls(string websiteUrl)
+                : this(websiteUrl, null)
+            {
+            }
+
+            /// <summary>
+            /// Initializes an instance of <see cref="VendorUrls"/>.
+            /// </summary>
+            /// <param name="websiteUrl">URL to a vendor's main web page.</param>
+            /// <param name="gameInfoBaseUrl">URL to a vendor's root game information page.</param>
+            internal VendorUrls(string websiteUrl, string gameInfoBaseUrl)
+                : base(websiteUrl, gameInfoBaseUrl)
+            {
+            }
+
+            /// <summary>
+            /// Gets the URL for a vendor's main website page.
+            /// </summary>
+            internal string WebsiteUrl
+            {
+                get { return Item1; }
+            }
+
+            /// <summary>
+            /// Gets the base URL to use for game information.
+            /// </summary>
+            internal string GameInfoBaseUrl
+            {
+                get { return Item2; }
+            }
         }
     }
 }

--- a/INTV.Core/Model/Program/LuigiFileMetadataProgramInformation.cs
+++ b/INTV.Core/Model/Program/LuigiFileMetadataProgramInformation.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="LuigiFileMetadataProgramInformation.cs" company="INTV Funhouse">
-// Copyright (c) 2016 All Rights Reserved
+// Copyright (c) 2016-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -29,12 +29,6 @@ namespace INTV.Core.Model.Program
     /// </summary>
     public class LuigiFileMetadataProgramInformation : ProgramInformation
     {
-        private string _title;
-        private string _vendor;
-        private string _year;
-        private CrcData _crc;
-        private ProgramFeatures _features;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="INTV.Core.Model.Program.LuigiFileMetadataProgramInformation"/> class.
         /// </summary>
@@ -73,6 +67,7 @@ namespace INTV.Core.Model.Program
             get { return _title; }
             set { _title = value; }
         }
+        private string _title;
 
         /// <inheritdoc />
         public override string Vendor
@@ -80,6 +75,7 @@ namespace INTV.Core.Model.Program
             get { return _vendor; }
             set { _vendor = value; }
         }
+        private string _vendor;
 
         /// <inheritdoc />
         public override string Year
@@ -87,6 +83,7 @@ namespace INTV.Core.Model.Program
             get { return _year; }
             set { _year = value; }
         }
+        private string _year;
 
         /// <inheritdoc />
         public override ProgramFeatures Features
@@ -94,126 +91,128 @@ namespace INTV.Core.Model.Program
             get { return _features; }
             set { _features = value; }
         }
+        private ProgramFeatures _features;
 
         /// <inheritdoc />
         public override IEnumerable<CrcData> Crcs
         {
             get { yield return _crc; }
         }
+        private CrcData _crc;
 
         #endregion // IProgramInformation
 
-        /// <summary>
-        /// Gets the authors.
-        /// </summary>
-        public IEnumerable<string> Authors
+        #region IProgramMetadata
+
+        /// <inheritdoc />
+        public override IEnumerable<string> LongNames
         {
-            get { return Metadata.Authors; }
+            get { return Metadata.LongNames; }
         }
 
-        /// <summary>
-        /// Gets the graphics artists.
-        /// </summary>
-        public IEnumerable<string> Graphics
+        /// <inheritdoc />
+        public override IEnumerable<string> ShortNames
         {
-            get { return Metadata.GraphicsCredits; }
+            get { return Metadata.ShortNames; }
         }
 
-        /// <summary>
-        /// Gets the music credits.
-        /// </summary>
-        public IEnumerable<string> Music
+        /// <inheritdoc />
+        public override IEnumerable<string> Descriptions
         {
-            get { return Metadata.MusicCredits; }
+            get { return Metadata.Descriptions; }
         }
 
-        /// <summary>
-        /// Gets the sound effects credits.
-        /// </summary>
-        public IEnumerable<string> SoundEffects
-        {
-            get { return Metadata.SoundEffectsCredits; }
-        }
-
-        /// <summary>
-        /// Gets the voice acting credits.
-        /// </summary>
-        public IEnumerable<string> Voices
-        {
-            get { return Metadata.VoiceActingCredits; }
-        }
-
-        /// <summary>
-        /// Gets the documentation credits.
-        /// </summary>
-        public IEnumerable<string> Documentation
-        {
-            get { return Metadata.DocumentationCredits; }
-        }
-
-        /// <summary>
-        /// Gets the artwork credits for boxes, et. al.
-        /// </summary>
-        public IEnumerable<string> Artwork
-        {
-            get { return Metadata.BoxOrOtherArtworkCredits; }
-        }
-
-        /// <summary>
-        /// Gets the program concept credits.
-        /// </summary>
-        public IEnumerable<string> Concept
-        {
-            get { return Metadata.ConceptAndDesignCredits; }
-        }
-
-        /// <summary>
-        /// Gets the 'more info' values.
-        /// </summary>
-        public IEnumerable<string> MoreInfo
-        {
-            get { return Metadata.UrlContactInfos; }
-        }
-
-        /// <summary>
-        /// Gets the publishers.
-        /// </summary>
-        public IEnumerable<string> Publishers
+        /// <inheritdoc />
+        public override IEnumerable<string> Publishers
         {
             get { return Metadata.Publishers; }
         }
 
-        /// <summary>
-        /// Gets the release licenses.
-        /// </summary>
-        public IEnumerable<string> Licenses
+        /// <inheritdoc />
+        public override IEnumerable<string> Programmers
         {
-            get { return Metadata.Licenses; }
+            get { return Metadata.Authors; }
         }
 
-        /// <summary>
-        /// Gets the release dates.
-        /// </summary>
-        public IEnumerable<MetadataDateTime> ReleaseDates
+        /// <inheritdoc />
+        public override IEnumerable<string> Designers
+        {
+            get { return Metadata.ConceptAndDesignCredits; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Graphics
+        {
+            get { return Metadata.GraphicsCredits; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Music
+        {
+            get { return Metadata.MusicCredits; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> SoundEffects
+        {
+            get { return Metadata.SoundEffectsCredits; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Voices
+        {
+            get { return Metadata.VoiceActingCredits; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Documentation
+        {
+            get { return Metadata.DocumentationCredits; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Artwork
+        {
+            get { return Metadata.BoxOrOtherArtworkCredits; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<MetadataDateTime> ReleaseDates
         {
             get { return Metadata.Dates; }
         }
 
-        /// <summary>
-        /// Gets the build dates.
-        /// </summary>
-        public IEnumerable<MetadataDateTime> BuildDates
+        /// <inheritdoc />
+        public override IEnumerable<string> Licenses
+        {
+            get { return Metadata.Licenses; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> ContactInformation
+        {
+            get { return Metadata.UrlContactInfos; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Versions
+        {
+            get { return Metadata.Versions; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<MetadataDateTime> BuildDates
         {
             get { return Metadata.BuildDates; }
         }
 
-        /// <summary>
-        /// Gets the versions.
-        /// </summary>
-        public IEnumerable<string> Versions
+        /// <inheritdoc />
+        public override IEnumerable<string> AdditionalInformation
         {
-            get { return Metadata.Versions; }
+            get { yield break; }
         }
+
+        #endregion // IProgramMetadata
 
         private LuigiMetadataBlock Metadata { get; set; }
 

--- a/INTV.Core/Model/Program/ProgramInformation.cs
+++ b/INTV.Core/Model/Program/ProgramInformation.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="ProgramInformation.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2015 All Rights Reserved
+// Copyright (c) 2014-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -25,12 +25,16 @@ namespace INTV.Core.Model.Program
     /// <summary>
     /// Provides partial implementation of IProgramInformation with some useful additions to it.
     /// </summary>
-    public abstract class ProgramInformation : IProgramInformation
+    public abstract class ProgramInformation : IProgramInformation, IProgramMetadata
     {
         /// <summary>
         /// Default name to use for an unrecognized program.
         /// </summary>
         public static readonly string UnknownProgramTitle = Resources.Strings.ProgramInformation_DefaultTitle;
+
+        #region Properties
+
+        #region IProgramInformation Properties
 
         /// <inheritdoc />
         public abstract ProgramInformationOrigin DataOrigin { get; }
@@ -53,6 +57,70 @@ namespace INTV.Core.Model.Program
         /// <inheritdoc />
         public abstract IEnumerable<CrcData> Crcs { get; }
 
+        #endregion // IProgramInformation Properties
+
+        #region IProgramMetadata Properties
+
+        /// <inheritdoc />
+        public abstract IEnumerable<string> LongNames { get; }
+
+        /// <inheritdoc />
+        public abstract IEnumerable<string> ShortNames { get; }
+
+        /// <inheritdoc />
+        public abstract IEnumerable<string> Descriptions { get; }
+
+        /// <inheritdoc />
+        public abstract IEnumerable<string> Publishers { get; }
+
+        /// <inheritdoc />
+        public abstract IEnumerable<string> Programmers { get; }
+
+        /// <inheritdoc />
+        public abstract IEnumerable<string> Designers { get; }
+
+        /// <inheritdoc />
+        public abstract IEnumerable<string> Graphics { get; }
+
+        /// <inheritdoc />
+        public abstract IEnumerable<string> Music { get; }
+
+        /// <inheritdoc />
+        public abstract IEnumerable<string> SoundEffects { get; }
+
+        /// <inheritdoc />
+        public abstract IEnumerable<string> Voices { get; }
+
+        /// <inheritdoc />
+        public abstract IEnumerable<string> Documentation { get; }
+
+        /// <inheritdoc />
+        public abstract IEnumerable<string> Artwork { get; }
+
+        /// <inheritdoc />
+        public abstract IEnumerable<MetadataDateTime> ReleaseDates { get; }
+
+        /// <inheritdoc />
+        public abstract IEnumerable<string> Licenses { get; }
+
+        /// <inheritdoc />
+        public abstract IEnumerable<string> ContactInformation { get; }
+
+        /// <inheritdoc />
+        public abstract IEnumerable<string> Versions { get; }
+
+        /// <inheritdoc />
+        public abstract IEnumerable<MetadataDateTime> BuildDates { get; }
+
+        /// <inheritdoc />
+        public abstract IEnumerable<string> AdditionalInformation { get; }
+
+        #endregion // IProgramMetadata Properties
+
+        #endregion // Properties
+
+        #region IProgramInformation Methods
+
         /// <inheritdoc />
         public abstract bool AddCrc(uint newCrc, string crcDescription, IncompatibilityFlags incompatibilities);
 
@@ -61,5 +129,7 @@ namespace INTV.Core.Model.Program
         {
             return IProgramInformationHelpers.ModifyCrc(this, crc, newCrcDescription, newIncompatibilityFlags);
         }
+
+        #endregion // IProgramInformation Methods
     }
 }

--- a/INTV.Core/Model/Program/RomFileMetadataProgramInformation.cs
+++ b/INTV.Core/Model/Program/RomFileMetadataProgramInformation.cs
@@ -28,12 +28,6 @@ namespace INTV.Core.Model.Program
     /// </summary>
     public class RomFileMetadataProgramInformation : ProgramInformation
     {
-        private string _title;
-        private string _vendor;
-        private string _year;
-        private CrcData _crc;
-        private ProgramFeatures _features;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="INTV.Core.Model.Program.RomFileMetadataProgramInformation"/> class.
         /// </summary>
@@ -91,6 +85,7 @@ namespace INTV.Core.Model.Program
             get { return _title; }
             set { _title = value; }
         }
+        private string _title;
 
         /// <inheritdoc />
         public override string Vendor
@@ -98,6 +93,7 @@ namespace INTV.Core.Model.Program
             get { return _vendor; }
             set { _vendor = value; }
         }
+        private string _vendor;
 
         /// <inheritdoc />
         public override string Year
@@ -105,6 +101,7 @@ namespace INTV.Core.Model.Program
             get { return _year; }
             set { _year = value; }
         }
+        private string _year;
 
         /// <inheritdoc />
         public override ProgramFeatures Features
@@ -112,134 +109,128 @@ namespace INTV.Core.Model.Program
             get { return _features; }
             set { _features = value; }
         }
+        private ProgramFeatures _features;
 
         /// <inheritdoc />
         public override IEnumerable<CrcData> Crcs
         {
             get { yield return _crc; }
         }
+        private CrcData _crc;
 
         #endregion IProgramInformation
 
-        /// <summary>
-        /// Gets the authors.
-        /// </summary>
-        public IEnumerable<string> Authors
+        #region IProgramMetadata
+
+        /// <inheritdoc />
+        public override IEnumerable<string> LongNames
         {
-            get { return Metadata.OfType<RomMetadataCredits>().SelectMany(c => c.Programming); }
+            get { return Metadata.OfType<RomMetadataString>().Where(m => m.Type == RomMetadataIdTag.Title).Select(m => m.StringValue); }
         }
 
-        /// <summary>
-        /// Gets the graphics artists.
-        /// </summary>
-        public IEnumerable<string> Graphics
+        /// <inheritdoc />
+        public override IEnumerable<string> ShortNames
         {
-            get { return Metadata.OfType<RomMetadataCredits>().SelectMany(c => c.Graphics); }
+            get { return Metadata.OfType<RomMetadataString>().Where(m => m.Type == RomMetadataIdTag.ShortTitle).Select(m => m.StringValue); }
         }
 
-        /// <summary>
-        /// Gets the music credits.
-        /// </summary>
-        public IEnumerable<string> Music
-        {
-            get { return Metadata.OfType<RomMetadataCredits>().SelectMany(c => c.Music); }
-        }
-
-        /// <summary>
-        /// Gets the sound effects credits.
-        /// </summary>
-        public IEnumerable<string> SoundEffects
-        {
-            get { return Metadata.OfType<RomMetadataCredits>().SelectMany(c => c.SoundEffects); }
-        }
-
-        /// <summary>
-        /// Gets the voice acting credits.
-        /// </summary>
-        public IEnumerable<string> Voices
-        {
-            get { return Metadata.OfType<RomMetadataCredits>().SelectMany(c => c.VoiceActing); }
-        }
-
-        /// <summary>
-        /// Gets the documentation credits.
-        /// </summary>
-        public IEnumerable<string> Documentation
-        {
-            get { return Metadata.OfType<RomMetadataCredits>().SelectMany(c => c.Documentation); }
-        }
-
-        /// <summary>
-        /// Gets the artwork credits for boxes, et. al.
-        /// </summary>
-        public IEnumerable<string> Artwork
-        {
-            get { return Metadata.OfType<RomMetadataCredits>().SelectMany(c => c.BoxOrOtherArtwork); }
-        }
-
-        /// <summary>
-        /// Gets the program concept credits.
-        /// </summary>
-        public IEnumerable<string> Concept
-        {
-            get { return Metadata.OfType<RomMetadataCredits>().SelectMany(c => c.GameConceptDesign); }
-        }
-
-        /// <summary>
-        /// Gets the 'more info' values.
-        /// </summary>
-        public IEnumerable<string> MoreInfo
-        {
-            get { return Metadata.OfType<RomMetadataString>().Where(m => m.Type == RomMetadataIdTag.UrlContactInfo).Select(m => m.StringValue); }
-        }
-
-        /// <summary>
-        /// Gets the publishers.
-        /// </summary>
-        public IEnumerable<string> Publishers
-        {
-            get { return Metadata.OfType<RomMetadataString>().Where(m => m.Type == RomMetadataIdTag.Publisher).Select(m => m.StringValue); }
-        }
-
-        /// <summary>
-        /// Gets the release licenses.
-        /// </summary>
-        public IEnumerable<string> Licenses
-        {
-            get { return Metadata.OfType<RomMetadataString>().Where(m => m.Type == RomMetadataIdTag.License).Select(m => m.StringValue); }
-        }
-
-        /// <summary>
-        /// Gets the descriptions.
-        /// </summary>
-        public IEnumerable<string> Descriptions
+        /// <inheritdoc />
+        public override IEnumerable<string> Descriptions
         {
             get { return Metadata.OfType<RomMetadataString>().Where(m => m.Type == RomMetadataIdTag.Description).Select(m => m.StringValue); }
         }
 
-        /// <summary>
-        /// Gets the release dates.
-        /// </summary>
-        public IEnumerable<MetadataDateTime> ReleaseDates
+        /// <inheritdoc />
+        public override IEnumerable<string> Publishers
+        {
+            get { return Metadata.OfType<RomMetadataString>().Where(m => m.Type == RomMetadataIdTag.Publisher).Select(m => m.StringValue); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Programmers
+        {
+            get { return Metadata.OfType<RomMetadataCredits>().SelectMany(c => c.Programming); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Designers
+        {
+            get { return Metadata.OfType<RomMetadataCredits>().SelectMany(c => c.GameConceptDesign); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Graphics
+        {
+            get { return Metadata.OfType<RomMetadataCredits>().SelectMany(c => c.Graphics); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Music
+        {
+            get { return Metadata.OfType<RomMetadataCredits>().SelectMany(c => c.Music); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> SoundEffects
+        {
+            get { return Metadata.OfType<RomMetadataCredits>().SelectMany(c => c.SoundEffects); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Voices
+        {
+            get { return Metadata.OfType<RomMetadataCredits>().SelectMany(c => c.VoiceActing); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Documentation
+        {
+            get { return Metadata.OfType<RomMetadataCredits>().SelectMany(c => c.Documentation); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Artwork
+        {
+            get { return Metadata.OfType<RomMetadataCredits>().SelectMany(c => c.BoxOrOtherArtwork); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<MetadataDateTime> ReleaseDates
         {
             get { return Metadata.OfType<RomMetadataDate>().Where(m => m.Type == RomMetadataIdTag.ReleaseDate).Select(m => m.Date); }
         }
 
-        /// <summary>
-        /// Gets the build dates.
-        /// </summary>
-        public IEnumerable<MetadataDateTime> BuildDates
+        /// <inheritdoc />
+        public override IEnumerable<string> Licenses
+        {
+            get { return Metadata.OfType<RomMetadataString>().Where(m => m.Type == RomMetadataIdTag.License).Select(m => m.StringValue); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> ContactInformation
+        {
+            get { return Metadata.OfType<RomMetadataString>().Where(m => m.Type == RomMetadataIdTag.UrlContactInfo).Select(m => m.StringValue); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Versions
+        {
+            get { return Metadata.OfType<RomMetadataString>().Where(m => m.Type == RomMetadataIdTag.Version).Select(m => m.StringValue); }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<MetadataDateTime> BuildDates
         {
             get { return Metadata.OfType<RomMetadataDate>().Where(m => m.Type == RomMetadataIdTag.BuildDate).Select(m => m.Date); }
         }
 
-        /// <summary>
-        /// Gets the versions.
-        /// </summary>
-        public IEnumerable<string> Versions
+        /// <inheritdoc />
+        public override IEnumerable<string> AdditionalInformation
         {
-            get { return Metadata.OfType<RomMetadataString>().Where(m => m.Type == RomMetadataIdTag.Version).Select(m => m.StringValue); }
+            get { yield break; }
         }
+
+        #endregion // IProgramMetadata
 
         /// <summary>
         /// Gets all the metadata in its originally parsed form.

--- a/INTV.Core/Model/Program/UnmergedProgramInformation.cs
+++ b/INTV.Core/Model/Program/UnmergedProgramInformation.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="UnmergedProgramInformation.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2015 All Rights Reserved
+// Copyright (c) 2014-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -28,12 +28,6 @@ namespace INTV.Core.Model.Program
     /// </summary>
     internal class UnmergedProgramInformation : ProgramInformation
     {
-        private string _title;
-        private string _vendor;
-        private string _year;
-        private List<CrcData> _crc;
-        private ProgramFeatures _features;
-
         /// <summary>
         /// Creates a new instance of the UnmergedProgramInformation class.
         /// </summary>
@@ -62,9 +56,9 @@ namespace INTV.Core.Model.Program
             _features = features;
         }
 
-        #region IProgramInformation
-
         #region Properties
+
+        #region IProgramInformation
 
         /// <inheritdoc />
         public override ProgramInformationOrigin DataOrigin
@@ -78,6 +72,7 @@ namespace INTV.Core.Model.Program
             get { return _title; }
             set { _title = value; }
         }
+        private string _title;
 
         /// <inheritdoc />
         public override ProgramFeatures Features
@@ -85,12 +80,14 @@ namespace INTV.Core.Model.Program
             get { return _features; }
             set { _features = value; }
         }
+        private ProgramFeatures _features;
 
         /// <inheritdoc />
         public override IEnumerable<CrcData> Crcs
         {
             get { return _crc; }
         }
+        private List<CrcData> _crc;
 
         /// <inheritdoc />
         public override string Vendor
@@ -98,6 +95,7 @@ namespace INTV.Core.Model.Program
             get { return _vendor; }
             set { _vendor = value; }
         }
+        private string _vendor;
 
         /// <inheritdoc />
         public override string Year
@@ -105,8 +103,125 @@ namespace INTV.Core.Model.Program
             get { return _year; }
             set { _year = value; }
         }
+        private string _year;
+
+        #endregion // IProgramInformation
+
+        #region IProgramMetadata
+
+        /// <inheritdoc />
+        public override IEnumerable<string> LongNames
+        {
+            get { yield break; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> ShortNames
+        {
+            get { yield break; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Descriptions
+        {
+            get { yield break; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Publishers
+        {
+            get { yield break; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Programmers
+        {
+            get { yield break; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Designers
+        {
+            get { yield break; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Graphics
+        {
+            get { yield break; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Music
+        {
+            get { yield break; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> SoundEffects
+        {
+            get { yield break; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Voices
+        {
+            get { yield break; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Documentation
+        {
+            get { yield break; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Artwork
+        {
+            get { yield break; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<MetadataDateTime> ReleaseDates
+        {
+            get { yield break; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Licenses
+        {
+            get { yield break; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> ContactInformation
+        {
+            get { yield break; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Versions
+        {
+            get { yield break; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<MetadataDateTime> BuildDates
+        {
+            get { yield break; }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> AdditionalInformation
+        {
+            get { yield break; }
+        }
+
+        #endregion // IProgramMetadata
 
         #endregion // Properties
+
+        #region IProgramInformation Methods
 
         /// <inheritdoc />
         public override bool AddCrc(uint newCrc, string crcDescription, IncompatibilityFlags incompatibilities)
@@ -114,6 +229,6 @@ namespace INTV.Core.Model.Program
             throw new NotImplementedException();
         }
 
-        #endregion IProgramInformation
+        #endregion // IProgramInformation Methods
     }
 }

--- a/INTV.Core/Model/Program/UserSpecifiedProgramInformation.cs
+++ b/INTV.Core/Model/Program/UserSpecifiedProgramInformation.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="UserSpecifiedProgramInformation.cs" company="INTV Funhouse">
-// Copyright (c) 2014 All Rights Reserved
+// Copyright (c) 2014-2018 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -21,6 +21,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using INTV.Core.ComponentModel;
 
@@ -33,14 +34,7 @@ namespace INTV.Core.Model.Program
     /// </summary>
     public class UserSpecifiedProgramInformation : ProgramInformation, INotifyPropertyChanged
     {
-        private bool _isDirty;
-        private string _title;
-        private string _vendor;
-        private string _year;
-        private ProgramFeatures _features;
-        private Dictionary<uint, KeyValuePair<string, IncompatibilityFlags>> _crcs = new Dictionary<uint, KeyValuePair<string, IncompatibilityFlags>>();
         private bool _initialized;
-        private ProgramInformationOrigin _origin;
 
         #region Constructors
 
@@ -125,7 +119,7 @@ namespace INTV.Core.Model.Program
             _features = features;
             _crcs[crc] = new KeyValuePair<string, IncompatibilityFlags>(crcDescription, incompatibilities);
             _origin = ProgramInformationOrigin.UserDefined;
-            _initialized = true;
+            FinishInitialization();
         }
 
         /// <summary>
@@ -154,7 +148,7 @@ namespace INTV.Core.Model.Program
             {
                 _crcs = programInformation.Crcs.ToDictionary(c => c.Crc, d => new KeyValuePair<string, IncompatibilityFlags>(d.Description, d.Incompatibilities));
             }
-            _initialized = true;
+            FinishInitialization();
         }
 
         private UserSpecifiedProgramInformation()
@@ -172,13 +166,14 @@ namespace INTV.Core.Model.Program
 
         #region Properties
 
-        #region IProgramInformation Properties
+        #region IProgramInformation
 
         /// <inheritdoc />
         public override ProgramInformationOrigin DataOrigin
         {
             get { return _origin; }
         }
+        private ProgramInformationOrigin _origin;
 
         /// <inheritdoc />
         public override string Title
@@ -196,6 +191,7 @@ namespace INTV.Core.Model.Program
                 }
             }
         }
+        private string _title;
 
         /// <inheritdoc />
         public override string Vendor
@@ -203,6 +199,7 @@ namespace INTV.Core.Model.Program
             get { return _vendor; }
             set { this.AssignAndUpdateProperty(PropertyChanged, "Vendor", value, ref _vendor, MarkDirty); }
         }
+        private string _vendor;
 
         /// <inheritdoc />
         public override string Year
@@ -210,6 +207,7 @@ namespace INTV.Core.Model.Program
             get { return _year; }
             set { this.AssignAndUpdateProperty(PropertyChanged, "Year", value, ref _year, MarkDirty); }
         }
+        private string _year;
 
         /// <inheritdoc />
         public override ProgramFeatures Features
@@ -217,14 +215,147 @@ namespace INTV.Core.Model.Program
             get { return _features; }
             set { this.AssignAndUpdateProperty(PropertyChanged, "Features", value, ref _features, MarkDirty); }
         }
+        private ProgramFeatures _features;
 
         /// <inheritdoc />
         public override IEnumerable<CrcData> Crcs
         {
             get { return _crcs.Select(crc => new CrcData(crc.Key, crc.Value)); }
         }
+        private Dictionary<uint, KeyValuePair<string, IncompatibilityFlags>> _crcs = new Dictionary<uint, KeyValuePair<string, IncompatibilityFlags>>();
 
-        #endregion // IProgramInformation Properties
+        #endregion // IProgramInformation
+
+        #region IProgramMetadata
+
+        /// <inheritdoc />
+        public override IEnumerable<string> LongNames
+        {
+            get { return _longNames; }
+        }
+        private HashSet<string> _longNames;
+
+        /// <inheritdoc />
+        public override IEnumerable<string> ShortNames
+        {
+            get { return _shortNames; }
+        }
+        private HashSet<string> _shortNames;
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Descriptions
+        {
+            get { return _descriptions; }
+        }
+        private HashSet<string> _descriptions;
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Publishers
+        {
+            get { return _publishers; }
+        }
+        private HashSet<string> _publishers;
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Programmers
+        {
+            get { return _programmers; }
+        }
+        private HashSet<string> _programmers;
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Designers
+        {
+            get { return _designers; }
+        }
+        private HashSet<string> _designers;
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Graphics
+        {
+            get { return _graphics; }
+        }
+        private HashSet<string> _graphics;
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Music
+        {
+            get { return _music; }
+        }
+        private HashSet<string> _music;
+
+        /// <inheritdoc />
+        public override IEnumerable<string> SoundEffects
+        {
+            get { return _soundEffects; }
+        }
+        private HashSet<string> _soundEffects;
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Voices
+        {
+            get { return _voices; }
+        }
+        private HashSet<string> _voices;
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Documentation
+        {
+            get { return _documentation; }
+        }
+        private HashSet<string> _documentation;
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Artwork
+        {
+            get { return _artwork; }
+        }
+        private HashSet<string> _artwork;
+
+        /// <inheritdoc />
+        public override IEnumerable<MetadataDateTime> ReleaseDates
+        {
+            get { return _releaseDates; }
+        }
+        private SortedSet<MetadataDateTime> _releaseDates;
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Licenses
+        {
+            get { return _licenses; }
+        }
+        private HashSet<string> _licenses;
+
+        /// <inheritdoc />
+        public override IEnumerable<string> ContactInformation
+        {
+            get { return _contactInformation; }
+        }
+        private HashSet<string> _contactInformation;
+
+        /// <inheritdoc />
+        public override IEnumerable<string> Versions
+        {
+            get { return _versions; }
+        }
+        private HashSet<string> _versions;
+
+        /// <inheritdoc />
+        public override IEnumerable<MetadataDateTime> BuildDates
+        {
+            get { return _buildDates; }
+        }
+        private SortedSet<MetadataDateTime> _buildDates;
+
+        /// <inheritdoc />
+        public override IEnumerable<string> AdditionalInformation
+        {
+            get { return GetAdditionalInformationString(); }
+        }
+
+        private Dictionary<string, string> _additionalInformation;
+
+        #endregion // IProgramMetadata
 
         /// <summary>
         /// Gets a value indicating whether the information has been modified or not.
@@ -234,6 +365,7 @@ namespace INTV.Core.Model.Program
             get { return _isDirty; }
             private set { this.AssignAndUpdateProperty(PropertyChanged, "IsModified", value, ref _isDirty); }
         }
+        private bool _isDirty;
 
         private IProgramInformation SourceInformation { get; set; }
 
@@ -256,9 +388,272 @@ namespace INTV.Core.Model.Program
 
         #endregion // IProgramInformation
 
+        /// <summary>
+        /// Adds a long name to the metadata. Duplicate values are rejected.
+        /// </summary>
+        /// <param name="longName">The long name to add.</param>
+        /// <returns><c>true</c> if the long name was added, <c>false</c> if the value was already in the long names list.</returns>
+        public bool AddLongName(string longName)
+        {
+            var added = _longNames.Add(longName);
+            return added;
+        }
+
+        /// <summary>
+        /// Adds a short name to the metadata. Duplicate values are rejected.
+        /// </summary>
+        /// <param name="shortName">The short name to add.</param>
+        /// <returns><c>true</c> if the short name was added, <c>false</c> if the value was already in the short names list.</returns>
+        public bool AddShortName(string shortName)
+        {
+            var added = _shortNames.Add(shortName);
+            return added;
+        }
+
+        /// <summary>
+        /// Adds a description to the metadata. Duplicate values are rejected.
+        /// </summary>
+        /// <param name="description">The description to add.</param>
+        /// <returns><c>true</c> if the description was added, <c>false</c> if the value was already in the description list.</returns>
+        public bool AddDescription(string description)
+        {
+            var added = _descriptions.Add(description);
+            return added;
+        }
+
+        /// <summary>
+        /// Adds a publisher credit to the metadata. Duplicate values are rejected.
+        /// </summary>
+        /// <param name="publisher">The publisher credit to add.</param>
+        /// <returns><c>true</c> if the publisher credit was added, <c>false</c> if the value was already in the publisher credits list.</returns>
+        public bool AddPublisher(string publisher)
+        {
+            var added = _publishers.Add(publisher);
+            return added;
+        }
+
+        /// <summary>
+        /// Adds a programmer credit to the metadata. Duplicate values are rejected.
+        /// </summary>
+        /// <param name="programmer">The programmer credit to add.</param>
+        /// <returns><c>true</c> if the programmer credit was added, <c>false</c> if the value was already in the programmer credits list.</returns>
+        public bool AddProgrammer(string programmer)
+        {
+            var added = _programmers.Add(programmer);
+            return added;
+        }
+
+        /// <summary>
+        /// Adds a designer credit to the metadata. Duplicate values are rejected.
+        /// </summary>
+        /// <param name="designer">The designer credit to add.</param>
+        /// <returns><c>true</c> if the designer credit was added, <c>false</c> if the value was already in the designer credits list.</returns>
+        public bool AddDesigner(string designer)
+        {
+            var added = _designers.Add(designer);
+            return added;
+        }
+
+        /// <summary>
+        /// Adds a graphics credit to the metadata. Duplicate values are rejected.
+        /// </summary>
+        /// <param name="graphics">The graphics credit to add.</param>
+        /// <returns><c>true</c> if the graphics credit was added, <c>false</c> if the value was already in the graphics credits list.</returns>
+        public bool AddGraphics(string graphics)
+        {
+            var added = _graphics.Add(graphics);
+            return added;
+        }
+
+        /// <summary>
+        /// Adds a music credit to the metadata. Duplicate values are rejected.
+        /// </summary>
+        /// <param name="music">The music credit to add.</param>
+        /// <returns><c>true</c> if the music credit was added, <c>false</c> if the value was already in the music credits list.</returns>
+        public bool AddMusic(string music)
+        {
+            var added = _music.Add(music);
+            return added;
+        }
+
+        /// <summary>
+        /// Adds a sound effects credit to the metadata. Duplicate values are rejected.
+        /// </summary>
+        /// <param name="soundEffects">The sound effects credit to add.</param>
+        /// <returns><c>true</c> if the sound effects credit was added, <c>false</c> if the value was already in the sound effects credits list.</returns>
+        public bool AddSoundEffects(string soundEffects)
+        {
+            var added = _soundEffects.Add(soundEffects);
+            return added;
+        }
+
+        /// <summary>
+        /// Adds a voice credit to the metadata. Duplicate values are rejected.
+        /// </summary>
+        /// <param name="voice">The voice credit to add.</param>
+        /// <returns><c>true</c> if the voice credit was added, <c>false</c> if the value was already in the voice credits list.</returns>
+        public bool AddVoice(string voice)
+        {
+            var added = _voices.Add(voice);
+            return added;
+        }
+
+        /// <summary>
+        /// Adds a documentation credit to the metadata. Duplicate values are rejected.
+        /// </summary>
+        /// <param name="documentation">The documentation credit to add.</param>
+        /// <returns><c>true</c> if the documentation credit was added, <c>false</c> if the value was already in the documentation credits list.</returns>
+        public bool AddDocumentation(string documentation)
+        {
+            var added = _documentation.Add(documentation);
+            return added;
+        }
+
+        /// <summary>
+        /// Adds an artwork credit to the metadata. Duplicate values are rejected.
+        /// </summary>
+        /// <param name="artwork">The artwork credit to add.</param>
+        /// <returns><c>true</c> if the artwork credit was added, <c>false</c> if the value was already in the artwork credits list.</returns>
+        public bool AddArtwork(string artwork)
+        {
+            var added = _artwork.Add(artwork);
+            return added;
+        }
+
+        /// <summary>
+        /// Adds a release date to the metadata. Duplicate values are rejected.
+        /// </summary>
+        /// <param name="releaseDate">The release date to add.</param>
+        /// <returns><c>true</c> if the release date was added, <c>false</c> if the value was already in the release dates list.</returns>
+        public bool AddReleaseDate(MetadataDateTime releaseDate)
+        {
+            var added = _releaseDates.Add(releaseDate);
+            return added;
+        }
+
+        /// <summary>
+        /// Adds a license to the metadata. Duplicate values are rejected.
+        /// </summary>
+        /// <param name="license">The license to add.</param>
+        /// <returns><c>true</c> if the license was added, <c>false</c> if the value was already in the licenses list.</returns>
+        public bool AddLicense(string license)
+        {
+            var added = _licenses.Add(license);
+            return added;
+        }
+
+        /// <summary>
+        /// Adds contact information to the metadata. Duplicate values are rejected.
+        /// </summary>
+        /// <param name="contactInformation">The contact information to add.</param>
+        /// <returns><c>true</c> if the contact information was added, <c>false</c> if the value was already in the contact information list.</returns>
+        public bool AddContactInformation(string contactInformation)
+        {
+            var added = _contactInformation.Add(contactInformation);
+            return added;
+        }
+
+        /// <summary>
+        /// Adds a version to the metadata. Duplicate values are rejected.
+        /// </summary>
+        /// <param name="version">The version to add.</param>
+        /// <returns><c>true</c> if the version was added, <c>false</c> if the value was already in the versions list.</returns>
+        public bool AddVersion(string version)
+        {
+            var added = _versions.Add(version);
+            return added;
+        }
+
+        /// <summary>
+        /// Adds a build date to the metadata. Duplicate values are rejected.
+        /// </summary>
+        /// <param name="buildDate">The build date to add.</param>
+        /// <returns><c>true</c> if the build date was added, <c>false</c> if the value was already in the build dates list.</returns>
+        public bool AddBuildDate(MetadataDateTime buildDate)
+        {
+            var added = _buildDates.Add(buildDate);
+            return added;
+        }
+
+        /// <summary>
+        /// Provide more supplemental information about the program to the metadata.
+        /// </summary>
+        /// <param name="key">An identifier for the additional information.</param>
+        /// <param name="value">The additional information.</param>
+        /// <remarks>If data is already present for the identifier described by <paramref name="key"/>, then <paramref name="value"/> is appended to the existing data.</remarks>
+        public void AddAdditionalInformation(string key, string value)
+        {
+            string existingInfo;
+            if (_additionalInformation.TryGetValue(key, out existingInfo))
+            {
+                existingInfo += ", " + value;
+            }
+            else
+            {
+                existingInfo = value;
+            }
+            _additionalInformation[key] = existingInfo;
+        }
+
+        private void FinishInitialization()
+        {
+            _longNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _shortNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _descriptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _publishers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _programmers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _designers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _graphics = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _music = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _soundEffects = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _voices = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _documentation = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _artwork = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _releaseDates = new SortedSet<MetadataDateTime>();
+            _licenses = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _contactInformation = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _versions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _buildDates = new SortedSet<MetadataDateTime>();
+            _additionalInformation = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            if (!string.IsNullOrEmpty(_title))
+            {
+                _longNames.Add(_title);
+            }
+
+            if (!string.IsNullOrEmpty(ShortName))
+            {
+                _shortNames.Add(ShortName);
+            }
+
+            if (!string.IsNullOrEmpty(_vendor))
+            {
+                AddPublisher(_vendor);
+            }
+
+            if (!string.IsNullOrEmpty(_year))
+            {
+                int releaseYear;
+                if (int.TryParse(_year, out releaseYear))
+                {
+                    var dateTime = new DateTime(releaseYear, MetadataDateTime.DefaultMonth, MetadataDateTime.DefaultDay);
+                    var releaseDate = new MetadataDateTime(dateTime, MetadataDateTimeFlags.Year);
+                    AddReleaseDate(releaseDate);
+                }
+            }
+
+            _initialized = true;
+        }
+
         private void MarkDirty<T>(string modifiedPropertyName, T newValue)
         {
             IsModified = _initialized;
+        }
+
+        private IEnumerable<string> GetAdditionalInformationString()
+        {
+            var additionalInfos = _additionalInformation.Select(i => string.Format(CultureInfo.CurrentCulture, "{0}: {1}", i.Key, i.Value));
+            return additionalInfos;
         }
     }
 }


### PR DESCRIPTION
This interface formalizes prior work done to harvest metadata from the various ROM formats supported by the jzintv emulator and **_LTO Flash!_** product. The INTV Funhouse database at the core of the ROM identification library also contains metadata now, though conflict resolution between what's in the ROM itself, and what's in the built-in database, has not been implemented.