### PR TITLE
Add uint FeaturesMask to feature helpers

### DIFF
--- a/INTV.Core/Model/Program/Bee3Features.cs
+++ b/INTV.Core/Model/Program/Bee3Features.cs
@@ -74,8 +74,13 @@ namespace INTV.Core.Model.Program
         public const Bee3Features Default = Bee3Features.Incompatible;
 
         /// <summary>
+        /// Mask to use to retrieve basic feature mask from larger flag sets.
+        /// </summary>
+        public const uint FeaturesMask = 0x1F;
+
+        /// <summary>
         /// Valid flags.
         /// </summary>
-        public const Bee3Features ValidFeaturesMask = (Bee3Features)0x1F;
+        public const Bee3Features ValidFeaturesMask = (Bee3Features)FeaturesMask;
     }
 }

--- a/INTV.Core/Model/Program/CuttleCart3Features.cs
+++ b/INTV.Core/Model/Program/CuttleCart3Features.cs
@@ -113,8 +113,13 @@ namespace INTV.Core.Model.Program
         public const CuttleCart3Features SerialPortMask = (CuttleCart3Features)(FeatureCompatibilityHelpers.CompatibilityMask << SerialPortOffset);
 
         /// <summary>
+        /// Mask to use to retrieve basic feature mask from larger flag sets.
+        /// </summary>
+        public const uint FeaturesMask = 0xFF;
+
+        /// <summary>
         /// Valid flags.
         /// </summary>
-        public const CuttleCart3Features ValidFeaturesMask = (CuttleCart3Features)0xFF;
+        public const CuttleCart3Features ValidFeaturesMask = (CuttleCart3Features)FeaturesMask;
     }
 }

--- a/INTV.Core/Model/Program/EcsFeatures.cs
+++ b/INTV.Core/Model/Program/EcsFeatures.cs
@@ -94,9 +94,14 @@ namespace INTV.Core.Model.Program
         public const EcsFeatures SerialPortMask = (EcsFeatures)(FeatureCompatibilityHelpers.CompatibilityMask << SerialPortOffset);
 
         /// <summary>
+        /// Mask to use to retrieve basic feature mask from larger flag sets.
+        /// </summary>
+        public const uint FeaturesMask = 0x7F;
+
+        /// <summary>
         /// Valid flags.
         /// </summary>
-        public const EcsFeatures ValidFeaturesMask = (EcsFeatures)0x7F;
+        public const EcsFeatures ValidFeaturesMask = (EcsFeatures)FeaturesMask;
 
         /// <summary>
         /// Converts EcsFeatures to LuigiFeatureFlags.

--- a/INTV.Core/Model/Program/GeneralFeatures.cs
+++ b/INTV.Core/Model/Program/GeneralFeatures.cs
@@ -59,9 +59,10 @@ namespace INTV.Core.Model.Program
     /// </summary>
     public static class GeneralFeaturesHelpers
     {
-        /// <summary>
-        /// Valid flags.
-        /// </summary>
-        public const GeneralFeatures ValidFeaturesMask = (GeneralFeatures)0x80000007;
+        /// <summary>Mask to use to retrieve basic feature mask from larger flag sets.</summary>
+        public const uint FeaturesMask = 0x80000007;
+
+        /// <summary>Valid flags.</summary>
+        public const GeneralFeatures ValidFeaturesMask = (GeneralFeatures)FeaturesMask;
     }
 }

--- a/INTV.Core/Model/Program/HiveFeatures.cs
+++ b/INTV.Core/Model/Program/HiveFeatures.cs
@@ -74,8 +74,13 @@ namespace INTV.Core.Model.Program
         public const HiveFeatures Default = HiveFeatures.Incompatible;
 
         /// <summary>
+        /// Mask to use to retrieve basic feature mask from larger flag sets.
+        /// </summary>
+        public const uint FeaturesMask = 0x1F;
+
+        /// <summary>
         /// Valid flags.
         /// </summary>
-        public const HiveFeatures ValidFeaturesMask = (HiveFeatures)0x1F;
+        public const HiveFeatures ValidFeaturesMask = (HiveFeatures)FeaturesMask;
     }
 }

--- a/INTV.Core/Model/Program/IntellicartCC3Features.cs
+++ b/INTV.Core/Model/Program/IntellicartCC3Features.cs
@@ -88,8 +88,13 @@ namespace INTV.Core.Model.Program
         public const IntellicartCC3Features SerialPortMask = (IntellicartCC3Features)(FeatureCompatibilityHelpers.CompatibilityMask << SerialPortOffset);
 
         /// <summary>
+        /// Mask to use to retrieve basic feature mask from larger flag sets.
+        /// </summary>
+        public const uint FeaturesMask = 0x3F;
+
+        /// <summary>
         /// Valid flags.
         /// </summary>
-        public const IntellicartCC3Features ValidFeaturesMask = (IntellicartCC3Features)0x3F;
+        public const IntellicartCC3Features ValidFeaturesMask = (IntellicartCC3Features)FeaturesMask;
     }
 }

--- a/INTV.Core/Model/Program/JlpFeatures.cs
+++ b/INTV.Core/Model/Program/JlpFeatures.cs
@@ -204,9 +204,14 @@ namespace INTV.Core.Model.Program
         public const JlpFeatures SerialPortMask = (JlpFeatures)(FeatureCompatibilityHelpers.CompatibilityMask << SerialPortOffset);
 
         /// <summary>
+        /// Mask to use to retrieve basic feature mask from larger flag sets.
+        /// </summary>
+        public const uint FeaturesMask = 0x1FF;
+
+        /// <summary>
         /// Valid flags.
         /// </summary>
-        public const JlpFeatures ValidFeaturesMask = (JlpFeatures)0x1FF;
+        public const JlpFeatures ValidFeaturesMask = (JlpFeatures)FeaturesMask;
 
         /// <summary>
         /// This mask can be used to recover the number of sectors a program using JLP Flash is using.

--- a/INTV.Core/Model/Program/KeyboardComponentFeatures.cs
+++ b/INTV.Core/Model/Program/KeyboardComponentFeatures.cs
@@ -129,9 +129,14 @@ namespace INTV.Core.Model.Program
         public const int PrinterOffset = BasicOffset + BasicFeatureBitCount;
 
         /// <summary>
+        /// Mask to use to retrieve basic feature mask from larger flag sets.
+        /// </summary>
+        public const uint FeaturesMask = 0x1FF;
+
+        /// <summary>
         /// Valid flags.
         /// </summary>
-        public const KeyboardComponentFeatures ValidFeaturesMask = (KeyboardComponentFeatures)0x1FF;
+        public const KeyboardComponentFeatures ValidFeaturesMask = (KeyboardComponentFeatures)FeaturesMask;
 
         /// <summary>
         /// Mask for extracting Microsoft Basic cartridge compatibility.

--- a/INTV.Core/Model/Program/LtoFlashFeatures.cs
+++ b/INTV.Core/Model/Program/LtoFlashFeatures.cs
@@ -156,6 +156,11 @@ namespace INTV.Core.Model.Program
             LtoFlashFeatures.SixteenBitRAM | LtoFlashFeatures.UsbPortEnhanced | LtoFlashFeatures.UsbPortRequired | LtoFlashFeatures.LtoFlashMemoryMapped;
 
         /// <summary>
+        /// Mask to use to retrieve basic feature mask from larger flag sets.
+        /// </summary>
+        public const uint FeaturesMask = (uint)ValidFeaturesMask;
+
+        /// <summary>
         /// Converts LtoFlashFeatures to LuigiFeatureFlags.
         /// </summary>
         /// <param name="features">The LTO Flash! features to convert.</param>


### PR DESCRIPTION
All the various FeaturesHelpers classes have a strongly-typed flags mask, but not one for uint manipulation. Add one to those without it.