### PR TITLE
Removed last vestiges of TFS SCC from projects

### DIFF
--- a/Locutus/Installer.desktop/Installer.desktop.isl
+++ b/Locutus/Installer.desktop/Installer.desktop.isl
@@ -4081,14 +4081,14 @@ UwBpAG4AZwBsAGUASQBtAGEAZwBlAAEARQB4AHAAcgBlAHMAcwA=
 		<row><td>PatchSequence</td><td>1.0.0</td></row>
 		<row><td>SaveAsSchema</td><td/></row>
 		<row><td>SccEnabled</td><td>0</td></row>
-		<row><td>SccPath</td><td>SAK</td></row>
+		<row><td>SccPath</td><td></td></row>
 		<row><td>SchemaVersion</td><td>776</td></row>
 		<row><td>SwidtagLocalComponent</td><td>ISO19770_LocalTag</td></row>
 		<row><td>SwidtagSystemComponent</td><td>ISO19770_SystemTag</td></row>
 		<row><td>Type</td><td>MSIE</td></row>
-		<row><td>VSSccAuxPath</td><td>SAK</td></row>
-		<row><td>VSSccLocalPath</td><td>SAK</td></row>
-		<row><td>VSSccProvider</td><td>SAK</td></row>
+		<row><td>VSSccAuxPath</td><td></td></row>
+		<row><td>VSSccLocalPath</td><td></td></row>
+		<row><td>VSSccProvider</td><td></td></row>
 	</table>
 
 	<table name="InstallUISequence">

--- a/Locutus/Installer.xp/Installer.xp.isl
+++ b/Locutus/Installer.xp/Installer.xp.isl
@@ -4080,14 +4080,14 @@ UwBpAG4AZwBsAGUASQBtAGEAZwBlAAEARQB4AHAAcgBlAHMAcwA=
 		<row><td>PatchSequence</td><td>1.0.0</td></row>
 		<row><td>SaveAsSchema</td><td/></row>
 		<row><td>SccEnabled</td><td>0</td></row>
-		<row><td>SccPath</td><td>SAK</td></row>
+		<row><td>SccPath</td><td></td></row>
 		<row><td>SchemaVersion</td><td>776</td></row>
 		<row><td>SwidtagLocalComponent</td><td>ISO19770_LocalTag</td></row>
 		<row><td>SwidtagSystemComponent</td><td>ISO19770_SystemTag</td></row>
 		<row><td>Type</td><td>MSIE</td></row>
-		<row><td>VSSccAuxPath</td><td>SAK</td></row>
-		<row><td>VSSccLocalPath</td><td>SAK</td></row>
-		<row><td>VSSccProvider</td><td>SAK</td></row>
+		<row><td>VSSccAuxPath</td><td></td></row>
+		<row><td>VSSccLocalPath</td><td></td></row>
+		<row><td>VSSccProvider</td><td></td></row>
 	</table>
 
 	<table name="InstallUISequence">

--- a/Locutus/Installer/Installer.vcxproj
+++ b/Locutus/Installer/Installer.vcxproj
@@ -12,10 +12,10 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{DAC23716-56DA-47F4-9045-A89460771098}</ProjectGuid>
-    <SccProjectName>SAK</SccProjectName>
-    <SccAuxPath>SAK</SccAuxPath>
-    <SccLocalPath>SAK</SccLocalPath>
-    <SccProvider>SAK</SccProvider>
+    <SccProjectName></SccProjectName>
+    <SccAuxPath></SccAuxPath>
+    <SccLocalPath></SccLocalPath>
+    <SccProvider></SccProvider>
     <Keyword>MakeFileProj</Keyword>
     <ProjectName>Installer.zip</ProjectName>
   </PropertyGroup>

--- a/Locutus/LtoFlash/LtoFlash.desktop.csproj
+++ b/Locutus/LtoFlash/LtoFlash.desktop.csproj
@@ -13,10 +13,10 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
-    <SccProjectName>SAK</SccProjectName>
-    <SccLocalPath>SAK</SccLocalPath>
-    <SccAuxPath>SAK</SccAuxPath>
-    <SccProvider>SAK</SccProvider>
+    <SccProjectName></SccProjectName>
+    <SccLocalPath></SccLocalPath>
+    <SccAuxPath></SccAuxPath>
+    <SccProvider></SccProvider>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Locutus/LtoFlash/LtoFlash.xp.csproj
+++ b/Locutus/LtoFlash/LtoFlash.xp.csproj
@@ -13,10 +13,10 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
-    <SccProjectName>SAK</SccProjectName>
-    <SccLocalPath>SAK</SccLocalPath>
-    <SccAuxPath>SAK</SccAuxPath>
-    <SccProvider>SAK</SccProvider>
+    <SccProjectName></SccProjectName>
+    <SccLocalPath></SccLocalPath>
+    <SccAuxPath></SccAuxPath>
+    <SccProvider></SccProvider>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>


### PR DESCRIPTION
The 'SAK' (Should Already Know) values of SCC-related tags caused warnings in the SCC output window during solution load.  Get rid of that noise.