### PR TITLE
Run LUIGI and ROM string metadata through un-escape code

### DIFF
--- a/INTV.Core/Model/MetadataHelpers.cs
+++ b/INTV.Core/Model/MetadataHelpers.cs
@@ -193,7 +193,7 @@ namespace INTV.Core.Model
             // LUIGI documentation indicates this could be ASCII or UTF-8 (LUIGI)...
             // ROM metadata spec says ASCII. Let's hope we don't run into anything *too* weird.
             var bytes = reader.ReadBytes((int)payloadLength);
-            var stringResult = System.Text.Encoding.UTF8.GetString(bytes, 0, (int)payloadLength).Trim('\0');
+            var stringResult = bytes.UnescapeFromBytePayload(null);
             if (stringResult.ContainsInvalidCharacters(allowLineBreaks))
             {
                 stringResult = string.Empty;


### PR DESCRIPTION
It is possible that I am misinterpreting the rules here.  Rule 1 in the unquote / unescape rules is that unless a string has first/last characters as quote, it should be returned as-is. However:
1. This is violated by intvname
2. IMO it is irrelevant in ROM and LUIGI metadata 

I.e. the rules are _primarily_ focused on CFGVAR data - the text .cfg files used with .bin format ROMs, where the more stringent rules are necessary.

Hopefully this is the case!  Since LUIGI and ROM string metadata is  described as a length followed by the string, special quoting rules are not really necessary.

Also: The quoting rules only appear to be used in bin+cfg-related code in jzintv/SDK-1600.