### PR TITLE
Add support for alternate MSYS path

### DIFF
--- a/Locutus/Installer.source/installer.source.bat
+++ b/Locutus/Installer.source/installer.source.bat
@@ -38,6 +38,16 @@ cd %1..\..
 call custom_bat_rule.bat
 
 rem # --------------------------------------------------------------------- #
+rem # Due to problems either with GitHub's svn support (see this page:      #
+rem # https://github.community/t5/GitHub-API-Development-and/Subversion-Bridge-Not-Supported-With-Latest-Subversion-Client/m-p/15454#M366 ) #
+rem # or a problem with MSYS2's build of svn or some supporting library,    #
+rem # support for an alternate version of MSYS has been added via the       #
+rem # MSYS_PATH_ALT variable. If it has been defined, the value overrides   #
+rem # MSYS_PATH for this build only.                                        #
+rem # --------------------------------------------------------------------- #
+if [%MSYS_PATH_ALT%] NEQ [] (set MSYS_PATH=%MSYS_PATH_ALT%)
+
+rem # --------------------------------------------------------------------- #
 rem # If MSYS_PATH is empty, there is nothing to do.
 rem # --------------------------------------------------------------------- #
 if [%MSYS_PATH%] == [] goto SkipBuild

--- a/custom_bat_rule.bat
+++ b/custom_bat_rule.bat
@@ -38,6 +38,9 @@ if exist custom.bat (
     echo rem # project build system and the MSYS / MSYS2 environment used to execute #>> custom.bat
     echo rem # makefiles in Windows. This is achieved by specifying the absolute     #>> custom.bat
     echo rem # to your MSYS environment in the MSYS_PATH environment variable.       #>> custom.bat
+    echo rem # Some projects support the use of the MSYS_PATH_ALT environment        #>> custom.bat
+    echo rem # variable, which will supersede MSYS_PATH. One such project is the     #>> custom.bat
+    echo rem # Installer.source project in Windows.                                  #>> custom.bat
     echo rem #                                                                       #>> custom.bat
     echo rem # NOTE: The path must be absolute, and to the MSYS 'bin' directory.     #>> custom.bat
     echo rem #########################################################################>> custom.bat


### PR DESCRIPTION
The MSYS2 version of svn (1.11 as of this submission) hangs when running svn export of the repo.  In fact, this happens even with older versions of svn in MSYS2.  The hang appears to be in msys-crypto-1.1.

To avoid this, support an alternative location of svn via MSYS.

This is only honored and used bin the Installer.source batch file builder in Windows.  Older versions of svn appear to work just fine in Windows.   Mac build is unaffected, but at the same time, it, too, is likely running an older version of svn.

If it is the case that it's svn-version-specific, then this needs to be addressed in a different way eventually.