### PR TITLE
When building installer, report error accurately if files are dirty

### DIFF
--- a/version.mak
+++ b/version.mak
@@ -164,11 +164,15 @@ ifneq ($(SVN_DIRTY),0)
 # ------------------------------------------------------------------------- #
 # This is simply a fancy multi-line string error message.
 # ------------------------------------------------------------------------- #
+SVN_DIRTY_REPO = $(SVN_REPO)
+ifeq (,)
+  SVN_DIRTY_REPO = $(GIT_REPO)
+endif
 define DIRTY_FILES_ERROR
 
 ERROR
 -----------------------------------------------------------------------------
-SVN repo: '$(SVN_REPO)'
+SVN repo: '$(SVN_DIRTY_REPO)'
 has $(SVN_DIRTY) modified file(s).
 Skipping version update.
 


### PR DESCRIPTION
The error messages was using the SVN_REPO value to report that there were dirty files, even when building using GitHub sources.

Now, if the SVN_REPO is empty, use the GIT_REPO name instead.  Since this house of cards only supports one repo at a time, this fix is good.  It now tells you the name of the repo that's got dirty files now instead of reporting a name of ''.