### PR TITLE
Incorporate UTF-8 support as specified in jzintv

### DIFF
--- a/INTV.Core/Model/MetadataHelpers.cs
+++ b/INTV.Core/Model/MetadataHelpers.cs
@@ -191,11 +191,11 @@ namespace INTV.Core.Model
         /// <returns>The string as parsed. If invalid characters are found, an empty string is returned.</returns>
         public static string ParseStringFromMetadata(this INTV.Core.Utility.BinaryReader reader, uint payloadLength, bool allowLineBreaks)
         {
-            // PCLs only support UTF8...
+            // PCLs only support UTF-8...
             // LUIGI documentation indicates this could be ASCII or UTF-8 (LUIGI)...
-            // ROM metadata spec says ASCII. Let's hope we don't run into anything *too* weird.
+            // ROM metadata spec supports UTF-8 as of jzintv version 1843 and later. Let's hope we don't run into anything *too* weird.
             var bytes = reader.ReadBytes((int)payloadLength);
-            var stringResult = bytes.UnescapeFromBytePayload(null);
+            var stringResult = System.Text.Encoding.UTF8.GetString(bytes, 0, bytes.Length).Trim('\0');
             if (stringResult.ContainsInvalidCharacters(allowLineBreaks))
             {
                 stringResult = string.Empty;

--- a/INTV.Core/Model/MetadataHelpers.cs
+++ b/INTV.Core/Model/MetadataHelpers.cs
@@ -18,6 +18,8 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 // </copyright>
 
+////#define ESCAPE_FOR_CFGVAR_SUPPORT
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -257,6 +259,9 @@ namespace INTV.Core.Model
             return indexes;
         }
 
+#if ESCAPE_FOR_CFGVAR_SUPPORT
+        // go look at SVN changes 1841-1849 for relevant information.
+
         /// <summary>
         /// Escapes the given string following the rules defined in the jzintv / SDK-1600 software stack.
         /// </summary>
@@ -287,12 +292,15 @@ namespace INTV.Core.Model
             /*                                                                          */
             /*          0x09 => \t, 0x0A => \n, 0x0D => \r.                             */
             /*                                                                          */
-            /*  4.  If a string contains any other character with a value below         */
+            /*  4.  If a string contains a valid UTF-8 encoded character, it is         */
+            /*      /not/ quoted, and is passed through unmodified.                     */
+            /*                                                                          */
+            /*  5.  If a string contains any other character with a value below         */
             /*      0x20 or a value above 0x7E, the string must be quoted, and the      */
             /*      character must be escaped.  The character will be escaped with      */
             /*      a hexadecimal escape.  0x00 => \x00.  0x7E => \x7E.                 */
             /*                                                                          */
-            /*  5.  If the string gets quoted, any backslashes must be escaped with     */
+            /*  6.  If the string gets quoted, any backslashes must be escaped with     */
             /*      a backslash.  e.g.  foo-bar\baz => "foo-bar\\baz".                  */
             /* ------------------------------------------------------------------------ */
             var bytePayload = new List<byte>();
@@ -357,6 +365,7 @@ namespace INTV.Core.Model
             }
             return bytePayload.ToArray();
         }
+#endif // ESCAPE_FOR_CFGVAR_SUPPORT
 
         /// <summary>
         /// Given a raw array of bytes intended to be converted to a UTF-8 string, and whose origins are a string,

--- a/INTV.Core/Model/RomMetadataCredits.cs
+++ b/INTV.Core/Model/RomMetadataCredits.cs
@@ -287,7 +287,7 @@ namespace INTV.Core.Model
         {
             // The format of the Credits block consists of:
             // 1 byte bit-field describing which credits apply to the subsequent name
-            // EITHER a 1-byte shorthand for the name (0x80-0xFF), or, a NULL-terminated ASCII string for the name.
+            // EITHER a 1-byte shorthand for the name (0x80-0xFF), or, a NULL-terminated UTF-8 string for the name.
             var bytesParsed = 0u;
             var creditFlags = (CreditFlags)reader.ReadByte();
             ++bytesParsed;
@@ -300,6 +300,14 @@ namespace INTV.Core.Model
 
             if (!Authors.TryGetValue(character, out name))
             {
+                // Discard the "stuffing" byte that indicates  UTF-8 or 0x01 should follow.
+                if (character == 0x01)
+                {
+                    character = reader.ReadByte();
+                    ++bytesParsed;
+                    ++runningTotal;
+                }
+
                 var nameBuffer = new List<byte>();
                 nameBuffer.Add(character);
 

--- a/INTV.Core/Utility/StringUtilities.cs
+++ b/INTV.Core/Utility/StringUtilities.cs
@@ -211,6 +211,7 @@ namespace INTV.Core.Utility
             return indexes;
         }
 
+#if ESCAPE_FOR_CFGVAR_SUPPORT
         /// <summary>
         /// Escapes the given string following the rules defined in the jzintv / SDK-1600 software stack.
         /// </summary>
@@ -224,6 +225,7 @@ namespace INTV.Core.Utility
             var escapedString = Encoding.UTF8.GetString(byteArray, 0, byteArray.Length);
             return escapedString;
         }
+#endif // ESCAPE_FOR_CFGVAR_SUPPORT
 
         /// <summary>
         /// Given a string, analyze the contents and un-escape the contents.

--- a/Tests/INTV.Core.Tests/Model/MetadataHelpersTests.cs
+++ b/Tests/INTV.Core.Tests/Model/MetadataHelpersTests.cs
@@ -405,6 +405,7 @@ namespace INTV.Core.Tests.Model
             Assert.Equal(expectedLastQuoteIndex, quoteIndexes.Maximum);
         }
 
+#if ESCAPE_FOR_CFGVAR_SUPPORT
         [Fact]
         public void MetadataHelpers_EscapeToBytePayloadWithNullString_ThrowsArgumentNullException()
         {
@@ -544,6 +545,7 @@ namespace INTV.Core.Tests.Model
             Assert.Equal(expectedPayloadData, payloadData);
             Assert.Equal(expectedPayloadAsString, payloadAsString);
         }
+#endif // ESCAPE_FOR_CFGVAR_SUPPORT
 
         [Fact]
         public void MetadataHelpers_UnescapeFromBytePayloadWithNullDataAndNullRange_ThrowsNullReferenceException()
@@ -619,6 +621,7 @@ namespace INTV.Core.Tests.Model
             Assert.Throws<IndexOutOfRangeException>(() => payload.UnescapeFromBytePayload(new Range<int>(10, 20)));
         }
 
+#if ESCAPE_FOR_CFGVAR_SUPPORT
         public static IEnumerable<object> EscapeUnescapeRoundTripTestData
         {
             get
@@ -641,6 +644,7 @@ namespace INTV.Core.Tests.Model
 
             Assert.Equal(stringToRoundTrip, unescapedString);
         }
+#endif // ESCAPE_FOR_CFGVAR_SUPPORT
 
         public static IEnumerable<object> OctalEncodedTestData
         {
@@ -721,6 +725,26 @@ namespace INTV.Core.Tests.Model
             var unescapedString = escaped.UnescapeFromBytePayload(null);
 
             Assert.Equal("Kröte", unescapedString);
+        }
+
+        [Fact]
+        public void MetadataHelpers_UnescapeStringWithTab_ProducesValidString()
+        {
+            var escaped = new byte[] { 0X54, 0x6F, 0x5C, 0x74, 0x61, 0x64 };
+
+            var unescapedString = escaped.UnescapeFromBytePayload(null);
+
+            Assert.Equal("To\tad", unescapedString);
+        }
+
+        [Fact]
+        public void MetadataHelpers_UnescapeStringWithCarriageReturn_ProducesValidString()
+        {
+            var escaped = new byte[] { 0X54, 0x6F, 0x5C, 0x72, 0x61, 0x64 };
+
+            var unescapedString = escaped.UnescapeFromBytePayload(null);
+
+            Assert.Equal("To\rad", unescapedString);
         }
 
         [Fact]

--- a/Tests/INTV.Core.Tests/Model/RomMetadataBlockTests.cs
+++ b/Tests/INTV.Core.Tests/Model/RomMetadataBlockTests.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="RomMetadataBlockTests.cs" company="INTV Funhouse">
-// Copyright (c) 2018 All Rights Reserved
+// Copyright (c) 2018-2019 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -20,6 +20,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using INTV.Core.Model;
 using INTV.Core.Utility;
 using Xunit;
@@ -105,6 +106,99 @@ namespace INTV.Core.Tests.Model
 
                     Assert.NotNull(metadataBlock);
                     Assert.Equal(RomMetadataIdTag.ControllerBindings, metadataBlock.Type);
+                }
+            }
+        }
+
+        [Fact]
+        public void RomMetadataBlock_InflateUtf8TestMetadata_ProducesExpectedMetadata()
+        {
+            var rawData = new byte[]
+            {
+                0x14, 0x01, 0xF0, 0x90, 0x80, 0x80, 0xF0, 0x90, 0x80, 0x81, 0x20, 0x30, 0x30, 0x20, 0xF0, 0x90,
+                0x80, 0x83, 0xF4, 0x8F, 0xBF, 0xBF, 0x9B, 0xBA, 0x15, 0x02, 0xFF, 0xF0, 0x90, 0x80, 0x80, 0xF0,
+                0x90, 0x80, 0x81, 0x20, 0x30, 0x36, 0x20, 0xF0, 0x90, 0x80, 0x83, 0xF4, 0x8F, 0xBF, 0xBF, 0x1C,
+                0xCC, 0x4F, 0x03, 0x03, 0x01, 0x01, 0xF0, 0x90, 0x80, 0x80, 0xF0, 0x90, 0x80, 0x81, 0x20, 0x31,
+                0x30, 0x20, 0xF0, 0x90, 0x80, 0x83, 0xF4, 0x8F, 0xBF, 0xBF, 0x00, 0xFF, 0x01, 0xF0, 0x90, 0x80,
+                0x80, 0xF0, 0x90, 0x80, 0x81, 0x20, 0x32, 0x30, 0x20, 0xF0, 0x90, 0x80, 0x83, 0xF4, 0x8F, 0xBF,
+                0xBF, 0x00, 0x02, 0x01, 0xF0, 0x90, 0x80, 0x80, 0xF0, 0x90, 0x80, 0x81, 0x20, 0x31, 0x31, 0x20,
+                0xF0, 0x90, 0x80, 0x83, 0xF4, 0x8F, 0xBF, 0xBF, 0x00, 0x04, 0x01, 0xF0, 0x90, 0x80, 0x80, 0xF0,
+                0x90, 0x80, 0x81, 0x20, 0x31, 0x32, 0x20, 0xF0, 0x90, 0x80, 0x83, 0xF4, 0x8F, 0xBF, 0xBF, 0x00,
+                0x08, 0x01, 0xF0, 0x90, 0x80, 0x80, 0xF0, 0x90, 0x80, 0x81, 0x20, 0x31, 0x33, 0x20, 0xF0, 0x90,
+                0x80, 0x83, 0xF4, 0x8F, 0xBF, 0xBF, 0x00, 0x10, 0x01, 0xF0, 0x90, 0x80, 0x80, 0xF0, 0x90, 0x80,
+                0x81, 0x20, 0x31, 0x34, 0x20, 0xF0, 0x90, 0x80, 0x83, 0xF4, 0x8F, 0xBF, 0xBF, 0x00, 0x20, 0x01,
+                0xF0, 0x90, 0x80, 0x80, 0xF0, 0x90, 0x80, 0x81, 0x20, 0x31, 0x35, 0x20, 0xF0, 0x90, 0x80, 0x83,
+                0xF4, 0x8F, 0xBF, 0xBF, 0x00, 0x40, 0x01, 0xF0, 0x90, 0x80, 0x80, 0xF0, 0x90, 0x80, 0x81, 0x20,
+                0x31, 0x36, 0x20, 0xF0, 0x90, 0x80, 0x83, 0xF4, 0x8F, 0xBF, 0xBF, 0x00, 0x80, 0x01, 0xF0, 0x90,
+                0x80, 0x80, 0xF0, 0x90, 0x80, 0x81, 0x20, 0x31, 0x37, 0x20, 0xF0, 0x90, 0x80, 0x83, 0xF4, 0x8F,
+                0xBF, 0xBF, 0x00, 0x3C, 0x36, 0x14, 0x04, 0xF0, 0x90, 0x80, 0x80, 0xF0, 0x90, 0x80, 0x81, 0x20,
+                0x30, 0x35, 0x20, 0xF0, 0x90, 0x80, 0x83, 0xF4, 0x8F, 0xBF, 0xBF, 0xEB, 0x87, 0x14, 0x08, 0xF0,
+                0x90, 0x80, 0x80, 0xF0, 0x90, 0x80, 0x81, 0x20, 0x30, 0x31, 0x20, 0xF0, 0x90, 0x80, 0x83, 0xF4,
+                0x8F, 0xBF, 0xBF, 0xEE, 0x7F, 0x14, 0x09, 0xF0, 0x90, 0x80, 0x80, 0xF0, 0x90, 0x80, 0x81, 0x20,
+                0x30, 0x32, 0x20, 0xF0, 0x90, 0x80, 0x83, 0xF4, 0x8F, 0xBF, 0xBF, 0x8A, 0x46, 0x14, 0x0A, 0xF0,
+                0x90, 0x80, 0x80, 0xF0, 0x90, 0x80, 0x81, 0x20, 0x30, 0x33, 0x20, 0xF0, 0x90, 0x80, 0x83, 0xF4,
+                0x8F, 0xBF, 0xBF, 0x8B, 0x38, 0x14, 0x0C, 0xF0, 0x90, 0x80, 0x80, 0xF0, 0x90, 0x80, 0x81, 0x20,
+                0x30, 0x34, 0x20, 0xF0, 0x90, 0x80, 0x83, 0xF4, 0x8F, 0xBF, 0xBF, 0x4B, 0xB4
+            };
+
+            using (var dataStream = new System.IO.MemoryStream(rawData, writable: false))
+            {
+                while (dataStream.Position < dataStream.Length)
+                {
+                    var metadataBlock = RomMetadataBlock.Inflate(dataStream);
+
+                    Assert.NotNull(metadataBlock);
+                    var stringMetadata = metadataBlock as RomMetadataString;
+                    switch (metadataBlock.Type)
+                    {
+                        case RomMetadataIdTag.Title:
+                            Assert.True(stringMetadata.StringValue.Contains(" 00 "));
+                            break;
+                        case RomMetadataIdTag.Publisher:
+                            var publisherMetadata = metadataBlock as RomMetadataPublisher;
+                            Assert.True(publisherMetadata.Publisher.Contains(" 06 "));
+                            break;
+                        case RomMetadataIdTag.Credits:
+                            var creditsMetadata = metadataBlock as RomMetadataCredits;
+                            Assert.NotNull(creditsMetadata.Programming.First(s => s.Contains(" 10 ")));
+                            Assert.NotNull(creditsMetadata.Graphics.First(s => s.Contains(" 11 ")));
+                            Assert.NotNull(creditsMetadata.Music.First(s => s.Contains(" 12 ")));
+                            Assert.NotNull(creditsMetadata.SoundEffects.First(s => s.Contains(" 13 ")));
+                            Assert.NotNull(creditsMetadata.VoiceActing.First(s => s.Contains(" 14 ")));
+                            Assert.NotNull(creditsMetadata.Documentation.First(s => s.Contains(" 15 ")));
+                            Assert.NotNull(creditsMetadata.GameConceptDesign.First(s => s.Contains(" 16 ")));
+                            Assert.NotNull(creditsMetadata.BoxOrOtherArtwork.First(s => s.Contains(" 17 ")));
+                            Assert.NotNull(creditsMetadata.Programming.First(s => s.Contains(" 20 ")));
+                            Assert.NotNull(creditsMetadata.Graphics.First(s => s.Contains(" 20 ")));
+                            Assert.NotNull(creditsMetadata.Music.First(s => s.Contains(" 20 ")));
+                            Assert.NotNull(creditsMetadata.SoundEffects.First(s => s.Contains(" 20 ")));
+                            Assert.NotNull(creditsMetadata.VoiceActing.First(s => s.Contains(" 20 ")));
+                            Assert.NotNull(creditsMetadata.Documentation.First(s => s.Contains(" 20 ")));
+                            Assert.NotNull(creditsMetadata.GameConceptDesign.First(s => s.Contains(" 20 ")));
+                            Assert.NotNull(creditsMetadata.BoxOrOtherArtwork.First(s => s.Contains(" 20 ")));
+                            break;
+                        case RomMetadataIdTag.UrlContactInfo:
+                            Assert.True(stringMetadata.StringValue.Contains(" 05 "));
+                            break;
+                        case RomMetadataIdTag.ShortTitle:
+                            Assert.True(stringMetadata.StringValue.Contains(" 01 "));
+                            break;
+                        case RomMetadataIdTag.License:
+                            Assert.True(stringMetadata.StringValue.Contains(" 02 "));
+                            break;
+                        case RomMetadataIdTag.Description:
+                            Assert.True(stringMetadata.StringValue.Contains(" 03 "));
+                            break;
+                        case RomMetadataIdTag.Version:
+                            Assert.True(stringMetadata.StringValue.Contains(" 04 "));
+                            break;
+                        case RomMetadataIdTag.ReleaseDate:
+                        case RomMetadataIdTag.BuildDate:
+                        case RomMetadataIdTag.Features:
+                        case RomMetadataIdTag.ControllerBindings:
+                        default:
+                            throw new InvalidOperationException("Invalid metadata in test");
+                    }
                 }
             }
         }

--- a/Tests/INTV.Core.Tests/Utility/StringUtilitiesTests.cs
+++ b/Tests/INTV.Core.Tests/Utility/StringUtilitiesTests.cs
@@ -182,6 +182,7 @@ namespace INTV.Core.Tests
 
         #endregion // GetEnclosingQuoteCharacterIndexes Tests
 
+#if ESCAPE_FOR_CFGVAR_SUPPORT
         #region EscapeString Tests
 
         [Fact]
@@ -206,6 +207,7 @@ namespace INTV.Core.Tests
         }
 
         #endregion // EscapeString Tests
+#endif // ESCAPE_FOR_CFGVAR_SUPPORT
 
         #region UnescapeString Tests
 


### PR DESCRIPTION
Also correct improper un-escaping of strings parsed from ROM and LUIGI metadata.  These strings are not escaped.