### PR TITLE
Fix ProgramDescription.Copy()

### DIFF
--- a/INTV.Core/Model/Program/ProgramDescription.cs
+++ b/INTV.Core/Model/Program/ProgramDescription.cs
@@ -66,7 +66,7 @@ namespace INTV.Core.Model.Program
             _crc = crc;
             _rom = rom;
             _programInfo = new UserSpecifiedProgramInformation(programInfo);
-            _xmlVendorName = new MetadataString() { Text = _programInfo.Vendor };
+            _xmlVendor = new MetadataString() { Text = _programInfo.Vendor };
             _name = _programInfo.GetNameForCrc(crc);
             _xmlName = new MetadataString() { Text = _name };
             _shortName = programInfo.ShortName;
@@ -182,7 +182,7 @@ namespace INTV.Core.Model.Program
                 var newVendor = value.EnforceNameLength(MaxVendorNameLength, false);
                 if (_programInfo.Vendor != newVendor)
                 {
-                    XmlVendorName.Text = newVendor;
+                    XmlVendor.Text = newVendor;
                     _programInfo.Vendor = newVendor;
                     RaisePropertyChanged(VendorPropertyName);
                 }
@@ -261,20 +261,20 @@ namespace INTV.Core.Model.Program
         /// </summary>
         /// <remarks>This should only be accessed via the XmlSerializer.</remarks>
         [System.Xml.Serialization.XmlElement(VendorPropertyName)]
-        public MetadataString XmlVendorName
+        public MetadataString XmlVendor
         {
             get
             {
-                return _xmlVendorName;
+                return _xmlVendor;
             }
 
             set
             {
-                _xmlVendorName = value;
-                Vendor = _xmlVendorName.Text;
+                _xmlVendor = value;
+                Vendor = _xmlVendor.Text;
             }
         }
-        private MetadataString _xmlVendorName;
+        private MetadataString _xmlVendor;
 
         /// <summary>
         /// Gets or sets XML-safe version of the <see cref="Name"/> property.

--- a/Tests/INTV.Core.Tests/Model/Program/ProgramDescriptionTests.cs
+++ b/Tests/INTV.Core.Tests/Model/Program/ProgramDescriptionTests.cs
@@ -564,6 +564,7 @@ namespace INTV.Core.Tests.Model.Program
 
             var description0 = new ProgramDescription(crc, null, information);
             description0.ShortName = "A\aa";
+            description0.Vendor = "V\vv";
             var description1 = description0.Copy();
 
             Assert.Equal(description0.Name, description1.Name);
@@ -571,11 +572,16 @@ namespace INTV.Core.Tests.Model.Program
             Assert.Equal(description0.Vendor, description1.Vendor);
             Assert.Equal(description0.Year, description1.Year);
             Assert.Equal(description0.Features, description1.Features);
+            Assert.False(object.ReferenceEquals(description0.XmlName, description1.XmlName));
             Assert.Equal(description0.XmlName.XmlText, description1.XmlName.XmlText);
             Assert.Equal(description0.XmlName.Escaped, description1.XmlName.Escaped);
+            Assert.False(object.ReferenceEquals(description0.XmlShortName, description1.XmlShortName));
             Assert.Equal(description0.XmlShortName.XmlText, description1.XmlShortName.XmlText);
             Assert.Equal(description0.XmlShortName.Escaped, description1.XmlShortName.Escaped);
             Assert.Equal(description0.Vendor, description1.Vendor);
+            Assert.False(object.ReferenceEquals(description0.XmlVendor, description1.XmlVendor));
+            Assert.Equal(description0.XmlVendor.XmlText, description1.XmlVendor.XmlText);
+            Assert.Equal(description0.XmlVendor.Escaped, description1.XmlVendor.Escaped);
             Assert.True(object.ReferenceEquals(description0.Rom, description1.Rom));
             VerifyProgramInformation(description0.ProgramInformation, description1.ProgramInformation);
             VerifyProgramSupportFiles(description0.Files, description1.Files);


### PR DESCRIPTION
Failed to make deep copy of XmlVendor.
Renamed XmlVendorName to XmlVendor.
Added test code for XmlVendor.
Added validation that MetadataString members were actually deep copied, not shallow-copied.