### PR TITLE
Fixed a build warning - assigned variable to itself

### DIFF
--- a/INTV.Core/Model/IRomHelpers.cs
+++ b/INTV.Core/Model/IRomHelpers.cs
@@ -633,7 +633,7 @@ namespace INTV.Core.Model
                         programMetadata = rom.GetRomFileMetadata();
                         break;
                     case RomFormat.Luigi:
-                        programMetadata = programMetadata = rom.GetLuigiFileMetadata();
+                        programMetadata = rom.GetLuigiFileMetadata();
                         break;
                 }
             }


### PR DESCRIPTION
Interesting that msbuild did not flag this, but Mono did.