### PR TITLE
Fix firmware resource extraction

### DIFF
--- a/INTV.LtoFlash/Commands/FirmwareCommandGroup.cs
+++ b/INTV.LtoFlash/Commands/FirmwareCommandGroup.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="FirmwareCommandGroup.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2017 All Rights Reserved
+// Copyright (c) 2014-2019 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -356,10 +356,6 @@ namespace INTV.LtoFlash.Commands
             }
         }
 
-        private const long FirmwareUpdateVersionOffset = 0xC0;
-        private const int FirmwareVersionSizeInBytes = 3;
-        private const int FirmwareVersionUnreleasedFlag = 1 << 0;
-        private const int FirmwareRevisionNeedsDoublingAfter = 0x08A2;
         private const int MinimumFirmwareUpdateFileSize = 0x1E004;
 
         /// <summary>
@@ -375,14 +371,7 @@ namespace INTV.LtoFlash.Commands
             {
                 using (var fileStream = FileUtilities.OpenFileStream(filePath))
                 {
-                    fileStream.Seek(FirmwareUpdateVersionOffset, System.IO.SeekOrigin.Begin);
-                    var versionBuffer = new byte[4];
-                    fileStream.Read(versionBuffer, 0, FirmwareVersionSizeInBytes);
-                    updateVersion = System.BitConverter.ToInt32(versionBuffer, 0);
-                    if (updateVersion > FirmwareRevisionNeedsDoublingAfter)
-                    {
-                        updateVersion *= 2;
-                    }
+                    updateVersion = FirmwareRevisions.GetFirmwareVersionFromBinaryImage(fileStream);
                 }
                 isValidFirmwareFile = true;
             }


### PR DESCRIPTION
Latest update had new firmware in resources, but the file was not being extracted to the file system because of a file name collision.

To address this, now the extracted files contain version information in the file name to disambiguate.

Need to ensure the YAML database support works correctly for finding the correct version of error_db.yaml.  That feature is not yet implemented in master, so it is not a critical path.

This most likely addresses issue #129.