### PR TITLE
Fix issue 129 - missing firmware update prompt

### DIFF
--- a/INTV.LtoFlash/INTV.LtoFlash.Gtk.csproj
+++ b/INTV.LtoFlash/INTV.LtoFlash.Gtk.csproj
@@ -363,6 +363,7 @@
     <Compile Include="Model\ControllerKeyValidationFlags.cs" />
     <Compile Include="Model\CrashLog.cs" />
     <Compile Include="Model\Device.cs" />
+    <Compile Include="Model\DeviceActivity.cs" />
     <Compile Include="Model\DeviceCommandAvailability.cs" />
     <Compile Include="Model\DeviceCreationInfo.cs" />
     <Compile Include="Model\DeviceHelpers.BackupFileSystem.cs" />

--- a/INTV.LtoFlash/INTV.LtoFlash.Mac.csproj
+++ b/INTV.LtoFlash/INTV.LtoFlash.Mac.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Model\Configuration.cs" />
     <Compile Include="Model\Device.cs" />
+    <Compile Include="Model\DeviceActivity.cs" />
     <Compile Include="Model\Directory.cs" />
     <Compile Include="Model\FileNode.cs" />
     <Compile Include="Model\FileSystem.cs" />

--- a/INTV.LtoFlash/INTV.LtoFlash.VSMac.csproj
+++ b/INTV.LtoFlash/INTV.LtoFlash.VSMac.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Model\Configuration.cs" />
     <Compile Include="Model\Device.cs" />
+    <Compile Include="Model\DeviceActivity.cs" />
     <Compile Include="Model\Directory.cs" />
     <Compile Include="Model\FileNode.cs" />
     <Compile Include="Model\FileSystem.cs" />

--- a/INTV.LtoFlash/INTV.LtoFlash.XamMac.csproj
+++ b/INTV.LtoFlash/INTV.LtoFlash.XamMac.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Model\Configuration.cs" />
     <Compile Include="Model\Device.cs" />
+    <Compile Include="Model\DeviceActivity.cs" />
     <Compile Include="Model\Directory.cs" />
     <Compile Include="Model\FileNode.cs" />
     <Compile Include="Model\FileSystem.cs" />

--- a/INTV.LtoFlash/INTV.LtoFlash.desktop.csproj
+++ b/INTV.LtoFlash/INTV.LtoFlash.desktop.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Model\ControllerKeyValidationFlags.cs" />
     <Compile Include="Model\CrashLog.cs" />
     <Compile Include="Model\Device.cs" />
+    <Compile Include="Model\DeviceActivity.cs" />
     <Compile Include="Model\DeviceCommandAvailability.cs" />
     <Compile Include="Model\DeviceCreationInfo.cs" />
     <Compile Include="Model\DeviceHelpers.cs" />

--- a/INTV.LtoFlash/INTV.LtoFlash.xp.csproj
+++ b/INTV.LtoFlash/INTV.LtoFlash.xp.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Model\ControllerKeyValidationFlags.cs" />
     <Compile Include="Model\CrashLog.cs" />
     <Compile Include="Model\Device.cs" />
+    <Compile Include="Model\DeviceActivity.cs" />
     <Compile Include="Model\DeviceCommandAvailability.cs" />
     <Compile Include="Model\DeviceCreationInfo.cs" />
     <Compile Include="Model\DeviceHelpers.cs" />

--- a/INTV.LtoFlash/Model/DeviceActivity.cs
+++ b/INTV.LtoFlash/Model/DeviceActivity.cs
@@ -1,0 +1,44 @@
+﻿// <copyright file="DeviceActivity.cs" company="INTV Funhouse">
+// Copyright (c) 2019 All Rights Reserved
+// <author>Steven A. Orth</author>
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this software. If not, see: http://www.gnu.org/licenses/.
+// or write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+// </copyright>
+
+namespace INTV.LtoFlash.Model
+{
+    /// <summary>
+    /// This enumerable lists the kinds of device 'activities' that may execute a specific points in time, such as
+    /// at device connect or application startup.
+    /// </summary>
+    internal enum DeviceActivity
+    {
+        /// <summary>
+        /// Nothing to do - sentinel value.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// When device connects, reconcile the menu layout in the editor with the menu layout on the device.
+        /// </summary>
+        ReconcileMenuOnConnect,
+
+        /// <summary>
+        /// When device connects, check whether a firmware update is available and if so, prompt to apply it.
+        /// </summary>
+        PromptForFirmwareUpdateOnConnect,
+    }
+}


### PR DESCRIPTION
Fix issue #129 - connecting cart does not prompt to update firmware.  There were two reasons, one already fixed and this being the originally discovered one.  These changes rework how 'stuff to do when cart connects' is handled to avoid losing the activity.