### PR TITLE
Update trademark info

### DIFF
--- a/INTV.Core/Properties/AssemblyInfo.cs
+++ b/INTV.Core/Properties/AssemblyInfo.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("INTVFunhouse")]
 [assembly: AssemblyProduct("VINTage")]
 [assembly: AssemblyCopyright("Copyright © INTV Funhouse 2013-" + INTV.VersionInfo.CurrentCopyrightYear)]
-[assembly: AssemblyTrademark("Intellivision® is a registered trademark of Intellivision Productions. Steve Orth and INTV Funhouse are not affiliated with Intellivision Productions.")]
+[assembly: AssemblyTrademark("Intellivision® is a registered trademark of Intellivision Entertainment, LLC. Steve Orth and INTV Funhouse are not affiliated with Intellivision Entertainment, LLC.")]
 [assembly: AssemblyCulture("")]
 ////[assembly: AssemblyMetadata(INTV.Core.Utility.ResourceHelpers.AuthorKey, "Steven A. Orth")]
 [assembly: NeutralResourcesLanguage("en")]

--- a/INTV.Intellicart/Properties/AssemblyInfo.cs
+++ b/INTV.Intellicart/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("INTVFunhouse")]
 [assembly: AssemblyProduct("VINTage")]
 [assembly: AssemblyCopyright("Copyright © INTV Funhouse 2014-" + INTV.VersionInfo.CurrentCopyrightYear)]
-[assembly: AssemblyTrademark("Intellivision® is a registered trademark of Intellivision Productions. Steve Orth and INTV Funhouse, and Chad Schell and Schell's Electronics, LLC are not affiliated with Intellivision Productions.")]
+[assembly: AssemblyTrademark("Intellivision® is a registered trademark of Intellivision Entertainment, LLC. Steve Orth and INTV Funhouse, and Chad Schell and Schell's Electronics, LLC are not affiliated with Intellivision Entertainment, LLC.")]
 //// Stupid xp... .NET 4.5 or later required for AssemblyMetadataAttribute
 #if !WIN
 [assembly: AssemblyMetadata(INTV.Core.Utility.ResourceHelpers.AuthorKey, "Steven A. Orth")]

--- a/INTV.Shared/Properties/AssemblyInfo.cs
+++ b/INTV.Shared/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("INTVFunhouse")]
 [assembly: AssemblyProduct("VINTage")]
 [assembly: AssemblyCopyright("Copyright © INTV Funhouse 2013-" + INTV.VersionInfo.CurrentCopyrightYear)]
-[assembly: AssemblyTrademark("Intellivision® is a registered trademark of Intellivision Productions. Steve Orth and INTV Funhouse are not affiliated with Intellivision Productions.")]
+[assembly: AssemblyTrademark("Intellivision® is a registered trademark of Intellivision Entertainment, LLC. Steve Orth and INTV Funhouse are not affiliated with Intellivision Entertainment, LLC.")]
 //// Stupid xp... .NET 4.5 or later required for AssemblyMetadataAttribute
 #if !WIN
 [assembly: AssemblyMetadata(INTV.Core.Utility.ResourceHelpers.AuthorKey, "Steven A. Orth")]

--- a/INTV.jzIntv/Properties/AssemblyInfo.cs
+++ b/INTV.jzIntv/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("INTVFunhouse")]
 [assembly: AssemblyProduct("VINTage")]
 [assembly: AssemblyCopyright("Copyright © INTV Funhouse 2013-" + INTV.VersionInfo.CurrentCopyrightYear)]
-[assembly: AssemblyTrademark("Intellivision® is a registered trademark of Intellivision Productions. Steve Orth and INTV Funhouse, and Joe Zbiciak and Left Turn Only, LLC are not affiliated with Intellivision Productions.")]
+[assembly: AssemblyTrademark("Intellivision® is a registered trademark of Intellivision Entertainment, LLC. Steve Orth and INTV Funhouse, and Joe Zbiciak and Left Turn Only, LLC are not affiliated with Intellivision Entertainment, LLC.")]
 //// Stupid xp... .NET 4.5 or later required for AssemblyMetadataAttribute
 #if !WIN
 [assembly: AssemblyMetadata(INTV.Core.Utility.ResourceHelpers.AuthorKey, "Steven A. Orth")]

--- a/INTV.jzIntvUI/Properties/AssemblyInfo.cs
+++ b/INTV.jzIntvUI/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("INTVFunhouse")]
 [assembly: AssemblyProduct("VINTage")]
 [assembly: AssemblyCopyright("Copyright © INTV Funhouse 2012-" + INTV.VersionInfo.CurrentCopyrightYear)]
-[assembly: AssemblyTrademark("Intellivision® is a registered trademark of Intellivision Productions. Steve Orth and INTV Funhouse, and Joe Zbiciak and Left Turn Only, LLC are not affiliated with Intellivision Productions.")]
+[assembly: AssemblyTrademark("Intellivision® is a registered trademark of Intellivision Entertainment, LLC. Steve Orth and INTV Funhouse, and Joe Zbiciak and Left Turn Only, LLC are not affiliated with Intellivision Entertainment, LLC.")]
 //// Stupid xp... .NET 4.5 or later required for AssemblyMetadataAttribute
 #if !WIN
 [assembly: AssemblyMetadata(INTV.Core.Utility.ResourceHelpers.AuthorKey, "Steven A. Orth")]

--- a/INTV.jzIntvUI/jzIntv/Getting_Started.html
+++ b/INTV.jzIntvUI/jzIntv/Getting_Started.html
@@ -32,21 +32,20 @@
       <li><b>OPTIONAL: </b>ECS.BIN (possibly also ECS.CFG and ECSPATCH.BIN)</li>
     </ul>
 
-    <p>These files have been available from <a href="http://www.intellivisionlives.com" target="_blank">Intellivision&nbsp;Productions</a>
-    in various products over the years. The best way to get these ROMs, as well as a nice collection of games, is to first check to see
-    if Intellivision Productions has a product available that contains these files. Recently, this has not been the case, meaning the
-    most effective way to properly get a copy of these files is to locate a copy of
-    <a href="http://intellivisionlives.com/retrotopia/lives.shtml" target="_blank">Intellivision&nbsp;Lives!</a>,
-    <a href="http://intellivisionlives.com/retrotopia/rocks.shtml" target="_blank">Intellivision&nbsp;Rocks</a>, or
-    <a href="http://intellivisionlives.com/retrotopia/greatesthits.shtml" target="_blank">Intellivision&nbsp;Greatest&nbsp;Hits</a>
-    for Windows or Mac.</p>
+    <p>These files have been available from <a href="https://www.blueskyrangers.com" target="_blank">Blue&nbsp;Sky&nbsp;Rangers,&nbsp;Inc.</a>
+    (previously Intellivision&nbsp;Productions,&nbsp;Inc.) in various products over the years. The best way to get these ROMs, as well as a
+    nice collection of games, is to first check to see if Blue Sky Rangers, Inc. or Intellivision Entertainment, LLC has a product available
+    that contains these files. Recently, this has not been the case, meaning the most effective way to properly get a copy of these files is
+    to locate a copy of <b><i>Intellivision&nbsp;Lives!</i></b>, <b><i>Intellivision&nbsp;Rocks</i></b>, or
+    <b><i>Intellivision&nbsp;Greatest&nbsp;Hits</i></b> for Windows or Mac.</p>
 
     <p>You can configure the location of these files from the jzIntv <b>Path</b> settings. If your copy of jzIntv already has
     a copy of these ROMs in the same directory as the jzintv program itself, you do not need to configure these paths.</p>
 
     <p><b>NOTE: </b>The included copy of jzIntv is located in the LUI application folder. It is better to configure the jzIntv
     settings to refer to these files in their current locations, rather than to copy them into the installed copy of <b>LUI</b>. Doing so ensures that
-    the support files will not be removed from your system if you choose to remove the program from your computer.</p>
+    the support files will not be removed from your system if you choose to remove the <b><i>LTO&nbsp;Flash!</i>&nbsp;User&nbsp;Interface&nbsp;Software</b>
+    from your computer.</p>
 
     <h3>Mac-Specific Requirements</h3>
     <p>On Mac OS X, the jzIntv emulator requires the SDL framework, version 1.2. A copy of the disk image for this
@@ -59,7 +58,7 @@
     a ROM in LUI and choose <b>Play&nbsp;in&nbsp;jzIntv</b>. You can also browse to locate a ROM on disk if you have
     not added it to your list. There are other ways in the UI to do this, too. Can you find them all?</p>
 
-    <p>As you explore the jzIntv settings, you will find that the power and flexibility of jzIntv is available. In most
+    <p>As you explore the jzIntv settings, you will find that all the power and flexibility of jzIntv is available. In most
     cases, LUI tries to just &quot;Do the right thing&quot; to run jzIntv with the necessary settings.</p>
 
     <h2>Special Thanks</h2>
@@ -70,8 +69,8 @@
     </table>
     
     <p align="center"><small>Intellivision<sup>&reg;</sup> is a registered trademark of
-     <a href="http://www.intellivisiongames.com" target="_blank">Intellivision&nbsp;Productions</a>.
+     <a href="https://www.intellivisionentertainment.com" target="_blank">Intellivision&nbsp;Entertainment,&nbsp;LLC.</a>.
      INTV&nbsp;Funhouse and Steve Orth, and Left&nbsp;Turn&nbsp;Only and Joe Zbiciak are not affiliated
-     with Intellivision&nbsp;Productions.</small></p>
+     with <a href="https://www.blueskyrangers.com" target="_blank">Blue&nbsp;Sky&nbsp;Rangers,&nbsp;Inc.</a> or Intellivision&nbsp;Entertainment,&nbsp;LLC.</small></p>
 </body>
 </html>

--- a/Locutus/LtoFlash/Properties/AssemblyInfo.cs
+++ b/Locutus/LtoFlash/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("INTVFunhouse")]
 [assembly: AssemblyProduct("LTOFlash")]
 [assembly: AssemblyCopyright("Copyright © INTV Funhouse 2014-" + INTV.VersionInfo.CurrentCopyrightYear)]
-[assembly: AssemblyTrademark("Intellivision® is a registered trademark of Intellivision Productions. LTO Flash! is a product from Left Turn Only, LLC. Steve Orth and INTV Funhouse, and Joe Zbiciak and Left Turn Only, LLC are not affiliated with Intellivision Productions.")]
+[assembly: AssemblyTrademark("Intellivision® is a registered trademark of Intellivision Entertainment, LLC. LTO Flash! is a product from Left Turn Only, LLC. Steve Orth and INTV Funhouse, and Joe Zbiciak and Left Turn Only, LLC are not affiliated with Intellivision Entertainment, LLC.")]
 //// Stupid xp... .NET 4.5 or later required for AssemblyMetadataAttribute
 #if !WIN_XP
 [assembly: AssemblyMetadata(INTV.Core.Utility.ResourceHelpers.AuthorKey, "Steven A. Orth")]

--- a/Locutus/LtoFlash/Resources/Credits.html
+++ b/Locutus/LtoFlash/Resources/Credits.html
@@ -3,10 +3,10 @@
 <b>Hardware, Firmware and Console Programming: </b>Joe Zbiciak<br>
 <b>Artwork: </b>Klay<br>
 <b>Box, Manual and Coordination: </b>William Moeller</br> -->
-Steve Orth and <a href="http://www.intvfunhouse.com">INTV&nbsp;Funhouse</a> and<br>
+Steve Orth and <a href="https://www.intvfunhouse.com">INTV&nbsp;Funhouse</a> and<br>
 Joe Zbiciak and <a href="http://leftturnonly.info">Left&nbsp;Turn&nbsp;Only,&nbsp;LLC</a><br>
 <!-- William Moeller and <a href="http://www.elektronite.com">Elektronite</a><br> -->
-are not affiliated with Intellivision Productions.<br>
+are not affiliated with Intellivision Entertainment, LLC.<br>
 <a href="full_credits.html">Credits</a><br><br>
 Intellivision<sup>&reg;</sup> is a registered trademark<br>
-of <a href="http://www.intellivisionlives.com">Intellivision&nbsp;Productions,&nbsp;Inc.</a></font></p>
+of <a href="https://www.intellivisionentertainment.com">Intellivision&nbsp;Entertainment,&nbsp;LLC.</a></font></p>

--- a/Locutus/LtoFlash/View/MainWindow.xaml
+++ b/Locutus/LtoFlash/View/MainWindow.xaml
@@ -191,7 +191,7 @@
                                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                                     <TextBlock Text="Steve Orth and "/>
                                     <TextBlock>
-                                        <Hyperlink NavigateUri="http://www.intvfunhouse.com"
+                                        <Hyperlink NavigateUri="https://www.intvfunhouse.com"
                                                    Command="{x:Static behaviors:ClickHyperlinkBehavior.ClickHyperlinkCommand}"
                                                    CommandParameter="{Binding Path=NavigateUri, RelativeSource={RelativeSource Self}}">
                                             INTV Funhouse
@@ -209,7 +209,7 @@
                                         </Hyperlink>
                                     </TextBlock>
                                 </StackPanel>
-                                <TextBlock HorizontalAlignment="Center" Text="are not affiliated with Intellivision Productions."/>
+                                <TextBlock HorizontalAlignment="Center" Text="are not affiliated with Intellivision Entertainment, LLC."/>
                                 <TextBlock HorizontalAlignment="Center" >
                                     <Hyperlink NavigateUri="{x:Static locutusViewModel:MainWindowViewModel.CreditsFilePath}"
                                                Command="{x:Static behaviors:ClickHyperlinkBehavior.ClickHyperlinkCommand}"
@@ -224,10 +224,10 @@
                             <StackPanel Grid.Row="6" Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Center">
                                 <TextBlock Text="of "/>
                                 <TextBlock>
-                                    <Hyperlink NavigateUri="http://www.intellivisionlives.com"
+                                    <Hyperlink NavigateUri="https://www.intellivisionentertainment.com"
                                                Command="{x:Static behaviors:ClickHyperlinkBehavior.ClickHyperlinkCommand}"
                                                CommandParameter="{Binding Path=NavigateUri, RelativeSource={RelativeSource Self}}">
-                                        Intellivision Productions, Inc.
+                                        Intellivision Entertainment, LLC.
                                     </Hyperlink>
                                 </TextBlock>
                             </StackPanel>


### PR DESCRIPTION
The Intellivision brand is now owned by Intellivision Entertainment, LLC. Intellivision Productions is now Blue Sky Rangers.

These changes update the links and references in two ways:
1. Intellivision brand ownership is now Intellivision Entertainment, LLC
2. References to Intellivision Productions, Inc. should now be Blue Sky Rangers, Inc.

Internally there is still code mapping (still in development) game metadata links to the old Intellivision Lives game information pages.  Those are no longer available.  When the new BSR site comes online as the successor to those, those changes will need to be made.