### PR TITLE
A ROM format metadata test failed in release builds

### DIFF
--- a/Tests/INTV.Core.Tests/Model/RomFormatRomTests.cs
+++ b/Tests/INTV.Core.Tests/Model/RomFormatRomTests.cs
@@ -129,7 +129,12 @@ namespace INTV.Core.Tests.Model
             var romPath = RomFormatRomTestStorageAccess.Initialize(TestRomResources.TestRomMetadataBadCrcPath).First();
             var rom = Rom.Create(romPath, null);
 
+#if DEBUG
             Assert.Throws<System.IO.InvalidDataException>(() => rom.GetRomFileMetadata());
+#else
+            var metadata = rom.GetRomFileMetadata();
+            Assert.NotNull(metadata);
+#endif // DEBUG
         }
 
         private void VerifyExpectedMetadata(IProgramMetadata metadata, bool lastVersionMetadataIsCorrupt)


### PR DESCRIPTION
Always had. It was testing a condition that arose specifically only in debug builds. Generally, the debug builds will throw when an error arises while parsing metadata - release builds will not. This test was expecting an exception simply because it was written and run in Debug builds.

In release, it now tests the expected result.