### PR TITLE
Add SharpZipLib-based implementation for gz support

### DIFF
--- a/INTV.Shared/INTV.Shared.Gtk.csproj
+++ b/INTV.Shared/INTV.Shared.Gtk.csproj
@@ -176,6 +176,7 @@
     <Compile Include="Utility\FileDialogHelpers.cs" />
     <Compile Include="Utility\FileUtilities.cs" />
     <Compile Include="Utility\FixedSizeCollection`T.cs" />
+    <Compile Include="Utility\GZipAccess.cs" />
     <Compile Include="Utility\GZipAccessNative.cs" />
     <Compile Include="Utility\GZipMemberEntry.cs" />
     <Compile Include="Utility\ICompressedArchiveAccess.cs" />

--- a/INTV.Shared/INTV.Shared.Gtk.csproj
+++ b/INTV.Shared/INTV.Shared.Gtk.csproj
@@ -176,8 +176,8 @@
     <Compile Include="Utility\FileDialogHelpers.cs" />
     <Compile Include="Utility\FileUtilities.cs" />
     <Compile Include="Utility\FixedSizeCollection`T.cs" />
+    <Compile Include="Utility\GZipAccessNative.cs" />
     <Compile Include="Utility\GZipMemberEntry.cs" />
-    <Compile Include="Utility\GZipNativeAccess.cs" />
     <Compile Include="Utility\ICompressedArchiveAccess.cs" />
     <Compile Include="Utility\ICompressedArchiveEntry.cs" />
     <Compile Include="Utility\IFileBrowserDialog.cs" />

--- a/INTV.Shared/INTV.Shared.Gtk.csproj
+++ b/INTV.Shared/INTV.Shared.Gtk.csproj
@@ -178,6 +178,7 @@
     <Compile Include="Utility\FixedSizeCollection`T.cs" />
     <Compile Include="Utility\GZipAccess.cs" />
     <Compile Include="Utility\GZipAccessNative.cs" />
+    <Compile Include="Utility\GZipAccessSharpZipLib.cs" />
     <Compile Include="Utility\GZipMemberEntry.cs" />
     <Compile Include="Utility\ICompressedArchiveAccess.cs" />
     <Compile Include="Utility\ICompressedArchiveEntry.cs" />

--- a/INTV.Shared/INTV.Shared.Mac.csproj
+++ b/INTV.Shared/INTV.Shared.Mac.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Utility\FileDialogHelpers.cs" />
     <Compile Include="Utility\FileUtilities.cs" />
     <Compile Include="Utility\FixedSizeCollection`T.cs" />
+    <Compile Include="Utility\GZipAccess.cs" />
     <Compile Include="Utility\GZipAccessNative.cs" />
     <Compile Include="Utility\GZipMemberEntry.cs" />
     <Compile Include="Utility\ICompressedArchiveAccess.cs" />

--- a/INTV.Shared/INTV.Shared.Mac.csproj
+++ b/INTV.Shared/INTV.Shared.Mac.csproj
@@ -77,8 +77,8 @@
     <Compile Include="Utility\FileDialogHelpers.cs" />
     <Compile Include="Utility\FileUtilities.cs" />
     <Compile Include="Utility\FixedSizeCollection`T.cs" />
+    <Compile Include="Utility\GZipAccessNative.cs" />
     <Compile Include="Utility\GZipMemberEntry.cs" />
-    <Compile Include="Utility\GZipNativeAccess.cs" />
     <Compile Include="Utility\ICompressedArchiveAccess.cs" />
     <Compile Include="Utility\ICompressedArchiveEntry.cs" />
     <Compile Include="Utility\IFileBrowserDialog.cs" />

--- a/INTV.Shared/INTV.Shared.Mac.csproj
+++ b/INTV.Shared/INTV.Shared.Mac.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Utility\FixedSizeCollection`T.cs" />
     <Compile Include="Utility\GZipAccess.cs" />
     <Compile Include="Utility\GZipAccessNative.cs" />
+    <Compile Include="Utility\GZipAccessSharpZipLib.cs" />
     <Compile Include="Utility\GZipMemberEntry.cs" />
     <Compile Include="Utility\ICompressedArchiveAccess.cs" />
     <Compile Include="Utility\ICompressedArchiveEntry.cs" />

--- a/INTV.Shared/INTV.Shared.VSMac.csproj
+++ b/INTV.Shared/INTV.Shared.VSMac.csproj
@@ -76,8 +76,8 @@
     <Compile Include="Utility\FileDialogHelpers.cs" />
     <Compile Include="Utility\FileUtilities.cs" />
     <Compile Include="Utility\FixedSizeCollection`T.cs" />
+    <Compile Include="Utility\GZipAccessNative.cs" />
     <Compile Include="Utility\GZipMemberEntry.cs" />
-    <Compile Include="Utility\GZipNativeAccess.cs" />
     <Compile Include="Utility\ICompressedArchiveAccess.cs" />
     <Compile Include="Utility\ICompressedArchiveEntry.cs" />
     <Compile Include="Utility\IFileBrowserDialog.cs" />

--- a/INTV.Shared/INTV.Shared.VSMac.csproj
+++ b/INTV.Shared/INTV.Shared.VSMac.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Utility\FileDialogHelpers.cs" />
     <Compile Include="Utility\FileUtilities.cs" />
     <Compile Include="Utility\FixedSizeCollection`T.cs" />
+    <Compile Include="Utility\GZipAccess.cs" />
     <Compile Include="Utility\GZipAccessNative.cs" />
     <Compile Include="Utility\GZipMemberEntry.cs" />
     <Compile Include="Utility\ICompressedArchiveAccess.cs" />

--- a/INTV.Shared/INTV.Shared.VSMac.csproj
+++ b/INTV.Shared/INTV.Shared.VSMac.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Utility\FixedSizeCollection`T.cs" />
     <Compile Include="Utility\GZipAccess.cs" />
     <Compile Include="Utility\GZipAccessNative.cs" />
+    <Compile Include="Utility\GZipAccessSharpZipLib.cs" />
     <Compile Include="Utility\GZipMemberEntry.cs" />
     <Compile Include="Utility\ICompressedArchiveAccess.cs" />
     <Compile Include="Utility\ICompressedArchiveEntry.cs" />

--- a/INTV.Shared/INTV.Shared.XamMac.csproj
+++ b/INTV.Shared/INTV.Shared.XamMac.csproj
@@ -76,8 +76,8 @@
     <Compile Include="Utility\FileDialogHelpers.cs" />
     <Compile Include="Utility\FileUtilities.cs" />
     <Compile Include="Utility\FixedSizeCollection`T.cs" />
+    <Compile Include="Utility\GZipAccessNative.cs" />
     <Compile Include="Utility\GZipMemberEntry.cs" />
-    <Compile Include="Utility\GZipNativeAccess.cs" />
     <Compile Include="Utility\ICompressedArchiveAccess.cs" />
     <Compile Include="Utility\ICompressedArchiveEntry.cs" />
     <Compile Include="Utility\IFileBrowserDialog.cs" />

--- a/INTV.Shared/INTV.Shared.XamMac.csproj
+++ b/INTV.Shared/INTV.Shared.XamMac.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Utility\FileDialogHelpers.cs" />
     <Compile Include="Utility\FileUtilities.cs" />
     <Compile Include="Utility\FixedSizeCollection`T.cs" />
+    <Compile Include="Utility\GZipAccess.cs" />
     <Compile Include="Utility\GZipAccessNative.cs" />
     <Compile Include="Utility\GZipMemberEntry.cs" />
     <Compile Include="Utility\ICompressedArchiveAccess.cs" />

--- a/INTV.Shared/INTV.Shared.XamMac.csproj
+++ b/INTV.Shared/INTV.Shared.XamMac.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Utility\FixedSizeCollection`T.cs" />
     <Compile Include="Utility\GZipAccess.cs" />
     <Compile Include="Utility\GZipAccessNative.cs" />
+    <Compile Include="Utility\GZipAccessSharpZipLib.cs" />
     <Compile Include="Utility\GZipMemberEntry.cs" />
     <Compile Include="Utility\ICompressedArchiveAccess.cs" />
     <Compile Include="Utility\ICompressedArchiveEntry.cs" />

--- a/INTV.Shared/INTV.Shared.desktop.csproj
+++ b/INTV.Shared/INTV.Shared.desktop.csproj
@@ -225,6 +225,7 @@
     <Compile Include="Utility\FileDialogHelpers.cs" />
     <Compile Include="Utility\FileUtilities.cs" />
     <Compile Include="Utility\FixedSizeCollection`T.cs" />
+    <Compile Include="Utility\GZipAccess.cs" />
     <Compile Include="Utility\GZipAccessNative.cs" />
     <Compile Include="Utility\GZipMemberEntry.cs" />
     <Compile Include="Utility\ICompressedArchiveAccess.cs" />

--- a/INTV.Shared/INTV.Shared.desktop.csproj
+++ b/INTV.Shared/INTV.Shared.desktop.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -225,8 +225,8 @@
     <Compile Include="Utility\FileDialogHelpers.cs" />
     <Compile Include="Utility\FileUtilities.cs" />
     <Compile Include="Utility\FixedSizeCollection`T.cs" />
+    <Compile Include="Utility\GZipAccessNative.cs" />
     <Compile Include="Utility\GZipMemberEntry.cs" />
-    <Compile Include="Utility\GZipNativeAccess.cs" />
     <Compile Include="Utility\ICompressedArchiveAccess.cs" />
     <Compile Include="Utility\ICompressedArchiveEntry.cs" />
     <Compile Include="Utility\IFileBrowserDialog.cs" />

--- a/INTV.Shared/INTV.Shared.desktop.csproj
+++ b/INTV.Shared/INTV.Shared.desktop.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -227,6 +227,7 @@
     <Compile Include="Utility\FixedSizeCollection`T.cs" />
     <Compile Include="Utility\GZipAccess.cs" />
     <Compile Include="Utility\GZipAccessNative.cs" />
+    <Compile Include="Utility\GZipAccessSharpZipLib.cs" />
     <Compile Include="Utility\GZipMemberEntry.cs" />
     <Compile Include="Utility\ICompressedArchiveAccess.cs" />
     <Compile Include="Utility\ICompressedArchiveEntry.cs" />

--- a/INTV.Shared/INTV.Shared.xp.csproj
+++ b/INTV.Shared/INTV.Shared.xp.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -201,8 +201,8 @@
     <Compile Include="Utility\FileDialogHelpers.cs" />
     <Compile Include="Utility\FileUtilities.cs" />
     <Compile Include="Utility\FixedSizeCollection`T.cs" />
+    <Compile Include="Utility\GZipAccessNative.cs" />
     <Compile Include="Utility\GZipMemberEntry.cs" />
-    <Compile Include="Utility\GZipNativeAccess.cs" />
     <Compile Include="Utility\ICompressedArchiveAccess.cs" />
     <Compile Include="Utility\ICompressedArchiveEntry.cs" />
     <Compile Include="Utility\IFileBrowserDialog.cs" />

--- a/INTV.Shared/INTV.Shared.xp.csproj
+++ b/INTV.Shared/INTV.Shared.xp.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -203,6 +203,7 @@
     <Compile Include="Utility\FixedSizeCollection`T.cs" />
     <Compile Include="Utility\GZipAccess.cs" />
     <Compile Include="Utility\GZipAccessNative.cs" />
+    <Compile Include="Utility\GZipAccessSharpZipLib.cs" />
     <Compile Include="Utility\GZipMemberEntry.cs" />
     <Compile Include="Utility\ICompressedArchiveAccess.cs" />
     <Compile Include="Utility\ICompressedArchiveEntry.cs" />

--- a/INTV.Shared/INTV.Shared.xp.csproj
+++ b/INTV.Shared/INTV.Shared.xp.csproj
@@ -201,6 +201,7 @@
     <Compile Include="Utility\FileDialogHelpers.cs" />
     <Compile Include="Utility\FileUtilities.cs" />
     <Compile Include="Utility\FixedSizeCollection`T.cs" />
+    <Compile Include="Utility\GZipAccess.cs" />
     <Compile Include="Utility\GZipAccessNative.cs" />
     <Compile Include="Utility\GZipMemberEntry.cs" />
     <Compile Include="Utility\ICompressedArchiveAccess.cs" />

--- a/INTV.Shared/Utility/CompressedArchiveAccess.cs
+++ b/INTV.Shared/Utility/CompressedArchiveAccess.cs
@@ -319,7 +319,7 @@ namespace INTV.Shared.Utility
             var factories = new ConcurrentDictionary<CompressedArchiveIdentifier, CompressedArchiveAccessFactory>(new CompressedArchiveIdentifier());
             factories[new CompressedArchiveIdentifier(CompressedArchiveFormat.Zip, CompressedArchiveAccessImplementation.Native)] = ZipArchiveAccess.Create;
             factories[new CompressedArchiveIdentifier(CompressedArchiveFormat.Zip, CompressedArchiveAccessImplementation.SharpZipLib)] = ZipArchiveAccessSharpZipLib.Create;
-            factories[new CompressedArchiveIdentifier(CompressedArchiveFormat.GZip, CompressedArchiveAccessImplementation.Native)] = GZipNativeAccess.Create;
+            factories[new CompressedArchiveIdentifier(CompressedArchiveFormat.GZip, CompressedArchiveAccessImplementation.Native)] = GZipAccessNative.Create;
             return factories;
         }
 

--- a/INTV.Shared/Utility/CompressedArchiveAccess.cs
+++ b/INTV.Shared/Utility/CompressedArchiveAccess.cs
@@ -320,6 +320,7 @@ namespace INTV.Shared.Utility
             factories[new CompressedArchiveIdentifier(CompressedArchiveFormat.Zip, CompressedArchiveAccessImplementation.Native)] = ZipArchiveAccess.Create;
             factories[new CompressedArchiveIdentifier(CompressedArchiveFormat.Zip, CompressedArchiveAccessImplementation.SharpZipLib)] = ZipArchiveAccessSharpZipLib.Create;
             factories[new CompressedArchiveIdentifier(CompressedArchiveFormat.GZip, CompressedArchiveAccessImplementation.Native)] = GZipAccessNative.Create;
+            factories[new CompressedArchiveIdentifier(CompressedArchiveFormat.GZip, CompressedArchiveAccessImplementation.SharpZipLib)] = GZipAccessSharpZipLib.Create;
             return factories;
         }
 

--- a/INTV.Shared/Utility/GZipAccess.cs
+++ b/INTV.Shared/Utility/GZipAccess.cs
@@ -1,0 +1,160 @@
+﻿// <copyright file="GZipAccess.cs" company="INTV Funhouse">
+// Copyright (c) 2019 All Rights Reserved
+// <author>Steven A. Orth</author>
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this software. If not, see: http://www.gnu.org/licenses/.
+// or write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace INTV.Shared.Utility
+{
+    /// <summary>
+    /// Provides common implementation for GZIP access.
+    /// </summary>
+    internal abstract class GZipAccess : CompressedArchiveAccess
+    {
+        protected GZipAccess(Stream stream, CompressedArchiveAccessMode mode)
+        {
+            IsReadOnly = mode == CompressedArchiveAccessMode.Read;
+            BaseStream = stream;
+            var fileStream = stream as FileStream;
+            if (fileStream != null)
+            {
+                RootLocation = fileStream.Name;
+            }
+            _entries = GZipMemberEntry.GetMemberEntries(stream, Properties.Settings.Default.MaxGZipEntriesSearch).ToList();
+            if (IsReadOnly)
+            {
+                if (!_entries.Any())
+                {
+                    throw new InvalidDataException(Resources.Strings.GZipAccess_NoEntriesFound);
+                }
+            }
+            else
+            {
+                if (_entries.Any())
+                {
+                    throw new InvalidOperationException(Resources.Strings.GZipAccess_EntriesAlreadyPresent);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public sealed override bool IsArchive
+        {
+            get { return false; }
+        }
+
+        /// <inheritdoc />
+        public sealed override bool IsCompressed
+        {
+            get { return true; }
+        }
+
+        /// <inheritdoc />
+        public sealed override IEnumerable<ICompressedArchiveEntry> Entries
+        {
+            get { return _entries; }
+        }
+        private List<GZipMemberEntry> _entries = new List<GZipMemberEntry>();
+
+        protected Stream BaseStream { get; private set; }
+
+        protected bool IsReadOnly { get; private set; }
+
+        /// <inheritdoc />
+        public override Stream OpenEntry(ICompressedArchiveEntry entry)
+        {
+            Stream entryStream = null;
+            var gzipEntry = GetEntry(entry.Name) as GZipMemberEntry;
+            if (gzipEntry != null)
+            {
+                BaseStream.Seek(gzipEntry.Offset, SeekOrigin.Begin);
+                entryStream = OpenStreamForEntry(gzipEntry);
+            }
+            return entryStream;
+        }
+
+        /// <inheritdoc />
+        public override ICompressedArchiveEntry CreateEntry(string name)
+        {
+            if (IsReadOnly)
+            {
+                throw new InvalidOperationException(Resources.Strings.GZipAccess_InvalidModeForCreateEntryError);
+            }
+            if (_entries.Count > 0)
+            {
+                throw new NotSupportedException(Resources.Strings.GZipAccess_MultipleMembersNotSupportedError);
+            }
+            var entry = GZipMemberEntry.CreateEmptyEntry(name);
+            _entries.Add(entry);
+            return entry;
+        }
+
+        /// <summary>
+        /// Validates the provided mode.
+        /// </summary>
+        /// <param name="mode">The mode to validate.</param>
+        /// <returns>The value of <paramref name="mode"/> if valid.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if an unsupported value for <paramref name="mode"/> is provided.</exception>
+        protected static CompressedArchiveAccessMode ValidateMode(CompressedArchiveAccessMode mode)
+        {
+            switch (mode)
+            {
+                case CompressedArchiveAccessMode.Read:
+                    break;
+                case CompressedArchiveAccessMode.Create:
+                case CompressedArchiveAccessMode.Update:
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+            return mode;
+        }
+
+        /// <summary>
+        /// Opens a stream for the given entry.
+        /// </summary>
+        /// <param name="entry">The entry to open the stream for.</param>
+        /// <returns>The stream to access the entry.</returns>
+        /// <remarks>Note that <see cref="BaseStream"/> will already be position to the beginning of the entry by the caller.</remarks>
+        protected abstract Stream OpenStreamForEntry(GZipMemberEntry entry);
+
+        /// <inheritdoc />
+        protected override bool DeleteEntry(ICompressedArchiveEntry entry)
+        {
+            throw new NotSupportedException(Resources.Strings.CompressedArchiveAccess_GZipDeleteEntryNotSupported);
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            if (BaseStream != null)
+            {
+                var baseStream = BaseStream;
+                BaseStream = null;
+                if (baseStream != null)
+                {
+                    baseStream.Dispose();
+                }
+            }
+        }
+    }
+}

--- a/INTV.Shared/Utility/GZipAccessNative.cs
+++ b/INTV.Shared/Utility/GZipAccessNative.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="GZipNativeAccess.cs" company="INTV Funhouse">
+﻿// <copyright file="GZipAccessNative.cs" company="INTV Funhouse">
 // Copyright (c) 2019 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
@@ -29,9 +29,9 @@ namespace INTV.Shared.Utility
     /// <summary>
     /// Provides access to a GZIP-formatted stream. Multiple-entry treatment is semi-supported. Don't have your hopes up too high, though.
     /// </summary>
-    internal sealed class GZipNativeAccess : CompressedArchiveAccess
+    internal sealed class GZipAccessNative : CompressedArchiveAccess
     {
-        private GZipNativeAccess(Stream stream, CompressionMode mode)
+        private GZipAccessNative(Stream stream, CompressionMode mode)
         {
             Mode = mode;
             BaseStream = stream;
@@ -82,16 +82,16 @@ namespace INTV.Shared.Utility
         private CompressionMode Mode { get; set; }
 
         /// <summary>
-        /// Creates a new instance of <see cref="GZipNativeAccess"/> using the given mode.
+        /// Creates a new instance of <see cref="GZipAccessNative"/> using the given mode.
         /// </summary>
         /// <param name="stream">Stream containing data in GZIP compressed format.</param>
         /// <param name="mode">The access mode to use for GZIP operations.</param>
-        /// <returns>A new instance of <see cref="GZipNativeAccess"/>.</returns>
+        /// <returns>A new instance of <see cref="GZipAccessNative"/>.</returns>
         /// <remarks>The GZIP implementation assumes ownership of <paramref name="stream"/> and will dispose it.</remarks>
-        public static GZipNativeAccess Create(Stream stream, CompressedArchiveAccessMode mode)
+        public static GZipAccessNative Create(Stream stream, CompressedArchiveAccessMode mode)
         {
             var compressionMode = CompressedArchiveAccessModeToCompressionMode(mode);
-            var gzipNativeAccess = new GZipNativeAccess(stream, compressionMode);
+            var gzipNativeAccess = new GZipAccessNative(stream, compressionMode);
             return gzipNativeAccess;
         }
 

--- a/INTV.Shared/Utility/GZipAccessSharpZipLib.cs
+++ b/INTV.Shared/Utility/GZipAccessSharpZipLib.cs
@@ -1,0 +1,65 @@
+﻿// <copyright file="GZipAccessSharpZipLib.cs" company="INTV Funhouse">
+// Copyright (c) 2019 All Rights Reserved
+// <author>Steven A. Orth</author>
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this software. If not, see: http://www.gnu.org/licenses/.
+// or write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+// </copyright>
+
+using System.IO;
+using ICSharpCode.SharpZipLib.GZip;
+
+namespace INTV.Shared.Utility
+{
+    /// <summary>
+    /// Provides access to a GZIP-formatted stream using SharpZipLib.
+    /// Multiple-entry treatment is semi-supported. Don't have your hopes up too high, though.
+    /// </summary>
+    internal sealed class GZipAccessSharpZipLib : GZipAccess
+    {
+        private GZipAccessSharpZipLib(Stream stream, CompressedArchiveAccessMode mode)
+            : base(stream, mode)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="GZipAccessSharpZipLib"/> using the given mode.
+        /// </summary>
+        /// <param name="stream">Stream containing data in GZIP compressed format.</param>
+        /// <param name="mode">The access mode to use for GZIP operations.</param>
+        /// <returns>A new instance of <see cref="GZipAccessSharpZipLib"/>.</returns>
+        /// <remarks>The GZIP implementation assumes ownership of <paramref name="stream"/> and will dispose it.</remarks>
+        public static GZipAccessSharpZipLib Create(Stream stream, CompressedArchiveAccessMode mode)
+        {
+            var gzipAccess = new GZipAccessSharpZipLib(stream, ValidateMode(mode));
+            return gzipAccess;
+        }
+
+        /// <inheritdoc />
+        protected override Stream OpenStreamForEntry(GZipMemberEntry entry)
+        {
+            Stream entryStream = null;
+            if (IsReadOnly)
+            {
+                entryStream = new GZipInputStream(BaseStream) { IsStreamOwner = false };
+            }
+            else
+            {
+                entryStream = new GZipOutputStream(BaseStream) { IsStreamOwner = false };
+            }
+            return entryStream;
+        }
+    }
+}

--- a/Tests/INTV.Shared.Tests/INTV.Shared.Tests.csproj
+++ b/Tests/INTV.Shared.Tests/INTV.Shared.Tests.csproj
@@ -66,7 +66,7 @@
     <Compile Include="Utility\CompressedArchiveAccessTests.cs" />
     <Compile Include="Utility\CompressedArchiveFormatTests.cs" />
     <Compile Include="Utility\GZipMemberEntryTests.cs" />
-    <Compile Include="Utility\GZipNativeAccessTests.cs" />
+    <Compile Include="Utility\GZipAccessTests.cs" />
     <Compile Include="Utility\ResourceHelpersTests.cs" />
     <Compile Include="Utility\ZipArchiveAccessTests.cs" />
   </ItemGroup>

--- a/Tests/INTV.Shared.Tests/Utility/GZipAccessTests.cs
+++ b/Tests/INTV.Shared.Tests/Utility/GZipAccessTests.cs
@@ -32,73 +32,85 @@ namespace INTV.Shared.Tests.Utility
 {
     public class GZipAccessTests
     {
-        [Fact]
-        public void GZipAccess_OpenNonGZip_ThrowsInvalidDataException()
+        [Theory]
+        [InlineData(CompressedArchiveAccessImplementation.Native)]
+        [InlineData(CompressedArchiveAccessImplementation.SharpZipLib)]
+        public void GZipAccess_OpenNonGZip_ThrowsInvalidDataException(CompressedArchiveAccessImplementation implementation)
         {
             var nonGZipResource = TestResource.TextEmbeddedResourceFile;
 
             using (var stream = nonGZipResource.OpenResourceForReading())
             {
-                Assert.Throws<InvalidDataException>(() => CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Read));
-            }
-        }
-
-        [Fact]
-        public void GZipAccess_OpenWithInvalidMode_ThrowsArgumentOutOfRangeException()
-        {
-            var gzipResource = TestResource.TagalongBinGZip;
-
-            using (var stream = gzipResource.OpenResourceForReading())
-            {
-                Assert.Throws<ArgumentOutOfRangeException>(() => CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, (CompressedArchiveAccessMode)100));
+                Assert.Throws<InvalidDataException>(() => CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Read, implementation));
             }
         }
 
         [Theory]
-        [InlineData(CompressedArchiveAccessMode.Create)]
-        [InlineData(CompressedArchiveAccessMode.Update)]
-        public void GZipAccess_OpenNonEmptyGZipForModification_ThrowsInvalidOperationException(CompressedArchiveAccessMode mode)
+        [InlineData(CompressedArchiveAccessImplementation.Native)]
+        [InlineData(CompressedArchiveAccessImplementation.SharpZipLib)]
+        public void GZipAccess_OpenWithInvalidMode_ThrowsArgumentOutOfRangeException(CompressedArchiveAccessImplementation implementation)
         {
             var gzipResource = TestResource.TagalongBinGZip;
 
             using (var stream = gzipResource.OpenResourceForReading())
             {
-                Assert.Throws<InvalidOperationException>(() => CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, mode));
+                Assert.Throws<ArgumentOutOfRangeException>(() => CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, (CompressedArchiveAccessMode)100, implementation));
             }
         }
 
-        [Fact]
-        public void GZipAccess_DeleteEntry_ThrowsNotSupportedException()
+        [Theory]
+        [InlineData(CompressedArchiveAccessMode.Create, CompressedArchiveAccessImplementation.Native)]
+        [InlineData(CompressedArchiveAccessMode.Create, CompressedArchiveAccessImplementation.SharpZipLib)]
+        [InlineData(CompressedArchiveAccessMode.Update, CompressedArchiveAccessImplementation.Native)]
+        [InlineData(CompressedArchiveAccessMode.Update, CompressedArchiveAccessImplementation.SharpZipLib)]
+        public void GZipAccess_OpenNonEmptyGZipForModification_ThrowsInvalidOperationException(CompressedArchiveAccessMode mode, CompressedArchiveAccessImplementation implementation)
+        {
+            var gzipResource = TestResource.TagalongBinGZip;
+
+            using (var stream = gzipResource.OpenResourceForReading())
+            {
+                Assert.Throws<InvalidOperationException>(() => CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, mode, implementation));
+            }
+        }
+
+        [Theory]
+        [InlineData(CompressedArchiveAccessImplementation.Native)]
+        [InlineData(CompressedArchiveAccessImplementation.SharpZipLib)]
+        public void GZipAccess_DeleteEntry_ThrowsNotSupportedException(CompressedArchiveAccessImplementation implementation)
         {
             var gzipResource = TestResource.TagalongCfgGZip;
             var entryName = gzipResource.ArchiveContents.First();
 
             var stream = gzipResource.OpenResourceForReading();
-            using (var gzip = CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Read))
+            using (var gzip = CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Read, implementation))
             {
                 Assert.Throws<NotSupportedException>(() => gzip.DeleteEntry(entryName));
             }
         }
 
-        [Fact]
-        public void GZipAccess_CreateEntryWhenOpenInDecompressMode_ThrowsInvalidOperationException()
+        [Theory]
+        [InlineData(CompressedArchiveAccessImplementation.Native)]
+        [InlineData(CompressedArchiveAccessImplementation.SharpZipLib)]
+        public void GZipAccess_CreateEntryWhenOpenInDecompressMode_ThrowsInvalidOperationException(CompressedArchiveAccessImplementation implementation)
         {
             var gzipResource = TestResource.TagalongCfgGZip;
 
             var stream = gzipResource.OpenResourceForReading();
-            using (var gzip = CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Read))
+            using (var gzip = CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Read, implementation))
             {
                 Assert.Throws<InvalidOperationException>(() => gzip.CreateEntry("derp"));
             }
         }
 
-        [Fact]
-        public void GZipAccess_OpenSingleMemberFileWithEntryName_HasExpectedContents()
+        [Theory]
+        [InlineData(CompressedArchiveAccessImplementation.Native)]
+        [InlineData(CompressedArchiveAccessImplementation.SharpZipLib)]
+        public void GZipAccess_OpenSingleMemberFileWithEntryName_HasExpectedContents(CompressedArchiveAccessImplementation implementation)
         {
             var gzipResource = TestResource.TagalongBinGZip;
 
             var stream = gzipResource.OpenResourceForReading();
-            using (var gzip = CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Read))
+            using (var gzip = CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Read, implementation))
             {
                 var entry = gzip.Entries.Single();
                 var crc = 0u;
@@ -112,13 +124,15 @@ namespace INTV.Shared.Tests.Utility
             }
         }
 
-        [Fact]
-        public void GZipAccess_OpenSecondMemberEntry_HasExpectedContents()
+        [Theory]
+        [InlineData(CompressedArchiveAccessImplementation.Native)]
+        [InlineData(CompressedArchiveAccessImplementation.SharpZipLib)]
+        public void GZipAccess_OpenSecondMemberEntry_HasExpectedContents(CompressedArchiveAccessImplementation implementation)
         {
             var gzipResource = TestResource.TagalongBinCfgYYGZip;
 
             var stream = gzipResource.OpenResourceForReading();
-            using (var gzip = CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Read))
+            using (var gzip = CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Read, implementation))
             {
                 var entry = gzip.Entries.Last();
                 var crc = 0u;
@@ -132,41 +146,49 @@ namespace INTV.Shared.Tests.Utility
             }
         }
 
-        [Fact]
-        public void GZipAccess_IsArchive_IsFalse()
+        [Theory]
+        [InlineData(CompressedArchiveAccessImplementation.Native)]
+        [InlineData(CompressedArchiveAccessImplementation.SharpZipLib)]
+        public void GZipAccess_IsArchive_IsFalse(CompressedArchiveAccessImplementation implementation)
         {
             var stream = new MemoryStream();
-            using (var gzip = CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Create))
+            using (var gzip = CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Create, implementation))
             {
                 Assert.False(gzip.IsArchive);
             }
         }
 
-        [Fact]
-        public void GZipAccess_IsCompressed_IsTrue()
+        [Theory]
+        [InlineData(CompressedArchiveAccessImplementation.Native)]
+        [InlineData(CompressedArchiveAccessImplementation.SharpZipLib)]
+        public void GZipAccess_IsCompressed_IsTrue(CompressedArchiveAccessImplementation implementation)
         {
             var stream = new MemoryStream();
-            using (var gzip = CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Create))
+            using (var gzip = CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Create, implementation))
             {
                 Assert.True(gzip.IsCompressed);
             }
         }
 
-        [Fact]
-        public void GZipAccess_CreateEntryInEmptyStream_Succeeds()
+        [Theory]
+        [InlineData(CompressedArchiveAccessImplementation.Native)]
+        [InlineData(CompressedArchiveAccessImplementation.SharpZipLib)]
+        public void GZipAccess_CreateEntryInEmptyStream_Succeeds(CompressedArchiveAccessImplementation implementation)
         {
             var stream = new MemoryStream();
-            using (var gzip = CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Create))
+            using (var gzip = CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Create, implementation))
             {
                 Assert.NotNull(gzip.CreateEntry("newEntry"));
             }
         }
 
-        [Fact]
-        public void GZipAccess_CreateSecondEntry_ThrowsNotSupportedException()
+        [Theory]
+        [InlineData(CompressedArchiveAccessImplementation.Native)]
+        [InlineData(CompressedArchiveAccessImplementation.SharpZipLib)]
+        public void GZipAccess_CreateSecondEntry_ThrowsNotSupportedException(CompressedArchiveAccessImplementation implementation)
         {
             var stream = new MemoryStream();
-            using (var gzip = CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Create))
+            using (var gzip = CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Create, implementation))
             {
                 gzip.CreateEntry("newEntry");
 
@@ -174,22 +196,28 @@ namespace INTV.Shared.Tests.Utility
             }
         }
 
-        [Fact]
-        public void GZipAccess_OpenFromDisk_HasExpectedContent()
+        [Theory]
+        [InlineData(CompressedArchiveAccessImplementation.Native)]
+        [InlineData(CompressedArchiveAccessImplementation.SharpZipLib)]
+        public void GZipAccess_OpenFromDisk_HasExpectedContent(CompressedArchiveAccessImplementation implementation)
         {
             var testResourcePath = ExtractTestResourceToTemporaryFile(TestResource.TagalongBinCfgNNGZip);
             try
             {
-                using (var gzip = CompressedArchiveAccess.Open(testResourcePath, CompressedArchiveAccessMode.Read))
+                using (var gzip = CompressedArchiveAccess.Open(testResourcePath, CompressedArchiveAccessMode.Read, implementation))
                 {
                     var expectedCrc32s = new[] { TestRomResources.TestBinCrc, TestRomResources.TestCfgCrc };
                     var i = 0;
                     foreach (var entry in gzip.Entries)
                     {
                         using (var entryStream = gzip.OpenEntry(entry))
+                        using (var validationStream = new MemoryStream())
                         {
-                            var crc = Crc32.OfStream(entryStream, fromStartOfStream: false);
-
+                            // Some implementations, e.g. SharpZipLib, inflate the ENTIRE contents of ALL members of a multi-member entry into one giant output,
+                            // so we need to read to an intermediate stream, then verify the output.
+                            entryStream.CopyTo(validationStream);
+                            validationStream.SetLength(entry.Length);
+                            var crc = Crc32.OfStream(validationStream);
                             Assert.Equal(expectedCrc32s[i], crc);
                         }
                         ++i;
@@ -213,8 +241,10 @@ namespace INTV.Shared.Tests.Utility
             }
         }
 
-        [Fact]
-        public void GZipAccess_WriteRomResourceToGZip_ProducesExpectedResult()
+        [Theory]
+        [InlineData(CompressedArchiveAccessImplementation.Native)]
+        [InlineData(CompressedArchiveAccessImplementation.SharpZipLib)]
+        public void GZipAccess_WriteRomResourceToGZip_ProducesExpectedResult(CompressedArchiveAccessImplementation implementation)
         {
             var inputCrc = 0u;
             var inputLength = 0L;
@@ -222,7 +252,7 @@ namespace INTV.Shared.Tests.Utility
             // Create in-memory GZIP
             var newMemoryStream = new MemoryStream();
             var copyMemoryStream = new MemoryStream();
-            using (var gzip = CompressedArchiveAccess.Open(newMemoryStream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Create))
+            using (var gzip = CompressedArchiveAccess.Open(newMemoryStream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Create, implementation))
             {
                 var testResourceName = "INTV.TestHelpers.Core.Resources.tagalong.luigi";
                 var newGZipEntryName = "tagalong.luigi";
@@ -240,7 +270,7 @@ namespace INTV.Shared.Tests.Utility
                 newMemoryStream.CopyTo(copyMemoryStream);
             }
 
-            using (var gzip = CompressedArchiveAccess.Open(copyMemoryStream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Read))
+            using (var gzip = CompressedArchiveAccess.Open(copyMemoryStream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Read, implementation))
             {
                 Assert.True(inputLength > copyMemoryStream.Length); // let's assume some kind of compression happened!
                 Assert.True(gzip.Entries.Any());
@@ -254,8 +284,10 @@ namespace INTV.Shared.Tests.Utility
             }
         }
 
-        [Fact]
-        public void GZipAccess_WriteRomResourceToGZipFile_ProducesExpectedResult()
+        [Theory]
+        [InlineData(CompressedArchiveAccessImplementation.Native)]
+        [InlineData(CompressedArchiveAccessImplementation.SharpZipLib)]
+        public void GZipAccess_WriteRomResourceToGZipFile_ProducesExpectedResult(CompressedArchiveAccessImplementation implementation)
         {
             var gzipFileName = TemporaryFile.GenerateUniqueFilePath("tagalong", ".luigi.gz");
 
@@ -264,7 +296,7 @@ namespace INTV.Shared.Tests.Utility
                 // Create on-disk GZIP
                 var inputLength = 0L;
                 var fileStream = new FileStream(gzipFileName, FileMode.Create, FileAccess.Write);
-                using (var gzip = CompressedArchiveAccess.Open(fileStream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Create))
+                using (var gzip = CompressedArchiveAccess.Open(fileStream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Create, implementation))
                 {
                     var testResourceName = "INTV.TestHelpers.Core.Resources.tagalong.luigi";
                     var newGZipEntryName = "tagalong.luigi";
@@ -284,7 +316,7 @@ namespace INTV.Shared.Tests.Utility
                     var fileInfo = new FileInfo(gzipFileName);
                     Assert.True(fileInfo.Exists);
                     Assert.True(inputLength > fileInfo.Length); // Compressed we must be! On this, all depends.
-                    using (var gzip = CompressedArchiveAccess.Open(gzipFileName, CompressedArchiveAccessMode.Read))
+                    using (var gzip = CompressedArchiveAccess.Open(gzipFileName, CompressedArchiveAccessMode.Read, implementation))
                     {
                         Assert.True(gzip.Entries.Any());
                         var entry = gzip.Entries.Single();

--- a/Tests/INTV.Shared.Tests/Utility/GZipAccessTests.cs
+++ b/Tests/INTV.Shared.Tests/Utility/GZipAccessTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="GZipNativeAccessTests.cs" company="INTV Funhouse">
+﻿// <copyright file="GZipAccessTests.cs" company="INTV Funhouse">
 // Copyright (c) 2019 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
@@ -30,10 +30,10 @@ using Xunit;
 
 namespace INTV.Shared.Tests.Utility
 {
-    public class GZipNativeAccessTests
+    public class GZipAccessTests
     {
         [Fact]
-        public void GZipNativeAccess_OpenNonGZip_ThrowsInvalidDataException()
+        public void GZipAccess_OpenNonGZip_ThrowsInvalidDataException()
         {
             var nonGZipResource = TestResource.TextEmbeddedResourceFile;
 
@@ -44,7 +44,7 @@ namespace INTV.Shared.Tests.Utility
         }
 
         [Fact]
-        public void GZipNativeAccess_OpenWithInvalidMode_ThrowsArgumentOutOfRangeException()
+        public void GZipAccess_OpenWithInvalidMode_ThrowsArgumentOutOfRangeException()
         {
             var gzipResource = TestResource.TagalongBinGZip;
 
@@ -57,7 +57,7 @@ namespace INTV.Shared.Tests.Utility
         [Theory]
         [InlineData(CompressedArchiveAccessMode.Create)]
         [InlineData(CompressedArchiveAccessMode.Update)]
-        public void GZipNativeAccess_OpenNonEmptyGZipForModification_ThrowsInvalidOperationException(CompressedArchiveAccessMode mode)
+        public void GZipAccess_OpenNonEmptyGZipForModification_ThrowsInvalidOperationException(CompressedArchiveAccessMode mode)
         {
             var gzipResource = TestResource.TagalongBinGZip;
 
@@ -68,7 +68,7 @@ namespace INTV.Shared.Tests.Utility
         }
 
         [Fact]
-        public void GZipNativeAccess_DeleteEntry_ThrowsNotSupportedException()
+        public void GZipAccess_DeleteEntry_ThrowsNotSupportedException()
         {
             var gzipResource = TestResource.TagalongCfgGZip;
             var entryName = gzipResource.ArchiveContents.First();
@@ -81,7 +81,7 @@ namespace INTV.Shared.Tests.Utility
         }
 
         [Fact]
-        public void GZipNativeAccess_CreateEntryWhenOpenInDecompressMode_ThrowsInvalidOperationException()
+        public void GZipAccess_CreateEntryWhenOpenInDecompressMode_ThrowsInvalidOperationException()
         {
             var gzipResource = TestResource.TagalongCfgGZip;
 
@@ -93,7 +93,7 @@ namespace INTV.Shared.Tests.Utility
         }
 
         [Fact]
-        public void GZipNativeAccess_OpenSingleMemberFileWithEntryName_HasExpectedContents()
+        public void GZipAccess_OpenSingleMemberFileWithEntryName_HasExpectedContents()
         {
             var gzipResource = TestResource.TagalongBinGZip;
 
@@ -113,7 +113,7 @@ namespace INTV.Shared.Tests.Utility
         }
 
         [Fact]
-        public void GZipNativeAccess_OpenSecondMemberEntry_HasExpectedContents()
+        public void GZipAccess_OpenSecondMemberEntry_HasExpectedContents()
         {
             var gzipResource = TestResource.TagalongBinCfgYYGZip;
 
@@ -133,7 +133,7 @@ namespace INTV.Shared.Tests.Utility
         }
 
         [Fact]
-        public void GZipNativeAccess_IsArchive_IsFalse()
+        public void GZipAccess_IsArchive_IsFalse()
         {
             var stream = new MemoryStream();
             using (var gzip = CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Create))
@@ -143,7 +143,7 @@ namespace INTV.Shared.Tests.Utility
         }
 
         [Fact]
-        public void GZipNativeAccess_IsCompressed_IsTrue()
+        public void GZipAccess_IsCompressed_IsTrue()
         {
             var stream = new MemoryStream();
             using (var gzip = CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Create))
@@ -153,7 +153,7 @@ namespace INTV.Shared.Tests.Utility
         }
 
         [Fact]
-        public void GZipNativeAccess_CreateEntryInEmptyStream_Succeeds()
+        public void GZipAccess_CreateEntryInEmptyStream_Succeeds()
         {
             var stream = new MemoryStream();
             using (var gzip = CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Create))
@@ -163,7 +163,7 @@ namespace INTV.Shared.Tests.Utility
         }
 
         [Fact]
-        public void GZipNativeAccess_CreateSecondEntry_ThrowsNotSupportedException()
+        public void GZipAccess_CreateSecondEntry_ThrowsNotSupportedException()
         {
             var stream = new MemoryStream();
             using (var gzip = CompressedArchiveAccess.Open(stream, CompressedArchiveFormat.GZip, CompressedArchiveAccessMode.Create))
@@ -175,7 +175,7 @@ namespace INTV.Shared.Tests.Utility
         }
 
         [Fact]
-        public void GZipNativeAccess_OpenFromDisk_HasExpectedContent()
+        public void GZipAccess_OpenFromDisk_HasExpectedContent()
         {
             var testResourcePath = ExtractTestResourceToTemporaryFile(TestResource.TagalongBinCfgNNGZip);
             try
@@ -214,7 +214,7 @@ namespace INTV.Shared.Tests.Utility
         }
 
         [Fact]
-        public void GZipNativeAccess_WriteRomResourceToGZip_ProducesExpectedResult()
+        public void GZipAccess_WriteRomResourceToGZip_ProducesExpectedResult()
         {
             var inputCrc = 0u;
             var inputLength = 0L;
@@ -255,7 +255,7 @@ namespace INTV.Shared.Tests.Utility
         }
 
         [Fact]
-        public void GZipNativeAccess_WriteRomResourceToGZipFile_ProducesExpectedResult()
+        public void GZipAccess_WriteRomResourceToGZipFile_ProducesExpectedResult()
         {
             var gzipFileName = TemporaryFile.GenerateUniqueFilePath("tagalong", ".luigi.gz");
 


### PR DESCRIPTION
This includes a small refactor to pull common code into a shared base class between the native and SharpZipLib versions.