### PR TITLE
Fix hard crash in WPF when dragging items to folder

### DIFF
--- a/INTV.LtoFlash/ViewModel/FileNodeViewModel.WPF.cs
+++ b/INTV.LtoFlash/ViewModel/FileNodeViewModel.WPF.cs
@@ -358,7 +358,18 @@ namespace INTV.LtoFlash.ViewModel
             var dragArgs = dragEventArgs as DragEventArgs;
             if (!dragArgs.Handled)
             {
-                AcceptDragData(dragArgs);
+                if (AcceptDragData(dragArgs))
+                {
+                    if (!dragArgs.Data.GetDataPresent(MenuLayoutViewModel.DragMenuLayoutDataFormat))
+                    {
+                        // This scenario can happen when the root cannot accept items, but sub-folders
+                        // CAN. E.g. the root has 254 items in it, and two or more items are being
+                        // being dragged over a child file within a folder that DOES have room.
+                        // See: https://github.com/intvsteve/VINTage/issues/343
+                        var menuLayout = CompositionHelpers.Container.GetExportedValue<LtoFlashViewModel>().HostPCMenuLayout;
+                        dragArgs.Data.SetData(MenuLayoutViewModel.DragMenuLayoutDataFormat, menuLayout);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
This fixes Issue #343

At issue is that the root of the file system is nearly full, which forbids dragging an item. However, the cart itself may not be full, so it's still possible to drag the file(s) to a sub-folder on the cart. When completing the drag, a necessary argument was set to `null`. This happened because the drag drop data that identifies the root menu layout ViewModel was never set.

The fix is simple - update that data during the drag once a valid drop target is hit.

There is an argument to be made that we could _always_ set this data, or never even need to set it and always just assume based on other application state. Perhaps for another day. This fix dovetails neatly into existing code, and makes use of a return value that was previously ignored.

The odd code layout (not using an AND) is a sop to unit test / code coverage plans for the future.