### PR TITLE
Fix for hard crash on macOS 10.11

### DIFF
--- a/INTV.LtoFlash/View/DeviceInformationController.Mac.cs
+++ b/INTV.LtoFlash/View/DeviceInformationController.Mac.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="DeviceInformationController.Mac.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2017 All Rights Reserved
+// Copyright (c) 2014-2021 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -410,6 +410,9 @@ namespace INTV.LtoFlash.View
             set { ViewModel.ActiveLtoFlashDevice.Keyclicks = value; }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the onboard configuration menu can be accessed from the cartridge.
+        /// </summary>
         [INTV.Shared.Utility.OSExport(Device.EnableConfigMenuOnCartPropertyName)]
         public bool EnableConfigMenuOnCart
         {

--- a/INTV.Shared/Utility/OSVersion.Mac.cs
+++ b/INTV.Shared/Utility/OSVersion.Mac.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="OSVersion.Mac.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2019 All Rights Reserved
+// Copyright (c) 2014-2021 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -55,6 +55,7 @@ namespace INTV.Shared.Utility
             // For reference, on Mac, Environment.OSVersion effectively returns the same value as sysctl kern.osrelease.
             // To map that to the well-known Mac releases, here's a handy dandy partial table from Stack Overflow:
             // See: https://stackoverflow.com/questions/11072804/how-do-i-determine-the-os-version-at-runtime-in-os-x-or-ios-without-using-gesta
+            // 20.x.x  macOS 11.x.x  Big Sur
             // 19.x.x  macOS 10.15.x Catalina
             // 18.x.x  macOS 10.14.x Mojave
             // 17.x.x  macOS 10.13.x High Sierra

--- a/Locutus/LtoFlash/View/MainWindow.Mac.cs
+++ b/Locutus/LtoFlash/View/MainWindow.Mac.cs
@@ -1,5 +1,5 @@
 // <copyright file="MainWindow.Mac.cs" company="INTV Funhouse">
-// Copyright (c) 2014-2017 All Rights Reserved
+// Copyright (c) 2014-2021 All Rights Reserved
 // <author>Steven A. Orth</author>
 //
 // This program is free software: you can redistribute it and/or modify it
@@ -26,9 +26,11 @@ using Locutus.ViewModel;
 #if __UNIFIED__
 using AppKit;
 using Foundation;
+using ObjCRuntime;
 #else
 using MonoMac.AppKit;
 using MonoMac.Foundation;
+using MonoMac.ObjCRuntime;
 #endif // __UNIFIED__
 
 namespace Locutus.View
@@ -65,7 +67,11 @@ namespace Locutus.View
         private void Initialize()
         {
 #if __UNIFIED__
-            NSWindow.AllowsAutomaticWindowTabbing = false;
+            var setAllowsAutomaticWindowTabbingSelector = new Selector("setAllowsAutomaticWindowTabbing:");
+            if (RespondsToSelector(setAllowsAutomaticWindowTabbingSelector))
+            {
+                NSWindow.AllowsAutomaticWindowTabbing = false;
+            }
 #endif // __UNIFIED__
             var viewModel = new Locutus.ViewModel.MainWindowViewModel();
             SingleInstanceApplication.Instance.DataContext = viewModel;


### PR DESCRIPTION
Do a run-time check before making call to disable window tab support to fix #345 . Some minor documentation updates too.